### PR TITLE
Update TooltipHandlerBurnTime.java

### DIFF
--- a/src/main/java/crazypants/enderio/gui/TooltipHandlerBurnTime.java
+++ b/src/main/java/crazypants/enderio/gui/TooltipHandlerBurnTime.java
@@ -51,6 +51,7 @@ public class TooltipHandlerBurnTime implements ITooltipCallback {
 
   @Override
   public boolean shouldHandleItem(ItemStack item) {
+    if (!Thread.currentThread().getName().startsWith("Client Thread")) return false;
     int time = TileEntityFurnace.getItemBurnTime(item);
     return time > 0 || isStirlingGen(item);
   }


### PR DESCRIPTION
After performance profiling I found 
TileEntityFurnace.getItemBurnTime(item); 
is computationaly expensive. It occupied almost a cpu core forever, because NEI starts a task thread every few seconds and this line of code keep iteraing through all the furnance recipe in GTNH. Besides, usually the result of this computation is not useful.

Add thread name check will help performance and will not influence the player.
if (!Thread.currentThread().getName().startsWith("Client Thread")) return false;