### PR TITLE
Update TileConduitBundle.java

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -19,6 +19,8 @@ import mods.immibis.microblocks.api.IMicroblockSystem;
 import mods.immibis.microblocks.api.MicroblockAPIUtils;
 import mods.immibis.microblocks.api.Part;
 import mods.immibis.microblocks.api.PartType;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -162,7 +164,19 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
     facadeMeta = nbtRoot.getInteger("facadeMeta");
 
     if(worldObj != null && worldObj.isRemote) {
-      clientUpdated = true;
+      if (conduits.size() == 1 && conduits.get(0) instanceof ItemConduit) {
+        boolean itemConduitClientUpdated = false;
+        for (Object o : Minecraft.getMinecraft().theWorld.playerEntities) {
+          Entity e = ((Entity) o);
+          if (e.getDistanceSq(this.xCoord, yCoord, zCoord) < 36) {
+            itemConduitClientUpdated = true;
+            break;
+          }
+        }
+        if (itemConduitClientUpdated) clientUpdated = true;
+      } else {
+        clientUpdated = true;
+      }
     }
 
     if (MicroblocksUtil.supportMicroblocks()) {

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -53,7 +53,6 @@ import crazypants.enderio.conduit.geom.ConduitConnectorType;
 import crazypants.enderio.conduit.geom.ConduitGeometryUtil;
 import crazypants.enderio.conduit.geom.Offset;
 import crazypants.enderio.conduit.geom.Offsets;
-import crazypants.enderio.conduit.item.ItemConduit;
 import crazypants.enderio.conduit.item.IItemConduit;
 import crazypants.enderio.conduit.liquid.ILiquidConduit;
 import crazypants.enderio.conduit.me.IMEConduit;
@@ -165,7 +164,7 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
     facadeMeta = nbtRoot.getInteger("facadeMeta");
 
     if(worldObj != null && worldObj.isRemote) {
-      if (conduits.size() == 1 && conduits.get(0) instanceof ItemConduit) {
+      if (conduits.size() == 1 && conduits.get(0) instanceof IItemConduit) {
         boolean itemConduitClientUpdated = false;
         for (Object o : Minecraft.getMinecraft().theWorld.playerEntities) {
           Entity e = ((Entity) o);

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -53,6 +53,7 @@ import crazypants.enderio.conduit.geom.ConduitConnectorType;
 import crazypants.enderio.conduit.geom.ConduitGeometryUtil;
 import crazypants.enderio.conduit.geom.Offset;
 import crazypants.enderio.conduit.geom.Offsets;
+import crazypants.enderio.conduit.item.ItemConduit;
 import crazypants.enderio.conduit.item.IItemConduit;
 import crazypants.enderio.conduit.liquid.ILiquidConduit;
 import crazypants.enderio.conduit.me.IMEConduit;


### PR DESCRIPTION
Greatly increase Client Side ItemConduit performance. (20% fps increase if have 100 - 200 item conduit in render area, these are lag-spikes.)

EnderIO Conduits are very laggy, partly because Redstone/fluid/gas Conduits causing RenderChunks re-render back and forth. But if there is only one ItemConduit in the bundle, it is pretty sure that we only need to re-render ItemConduit near the player , because only in player's behavior range (5) and the player's behavior can change the shape of ItemConduit. 
But if there is another conduit in the bundle, the re-render is not sure because Redstone / liquid energy conduit in the bundle might needs to re-render in any time. So in this case I left to default.