### PR TITLE
Ignore dead entities when capturing mobs with soul vial

### DIFF
--- a/src/main/java/crazypants/enderio/item/ItemSoulVessel.java
+++ b/src/main/java/crazypants/enderio/item/ItemSoulVessel.java
@@ -185,6 +185,9 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
     if(entity instanceof EntityPlayer) {
       return false;
     }
+    if(entity.isDead) {
+      return false;
+    }
 
     String entityId = EntityList.getEntityString(entity);
     if(isBlackListed(entityId)) {


### PR DESCRIPTION
See GTNewHorizons/GT-New-Horizons-Modpack#6867

If the client sends `C02PacketUseEntity` too quickly then `itemInteractionForEntity` can be called with a dead entity as argument. There is nothing in vanilla/forge code to stop this. 

Imagine 2 `C02PacketUseEntity` arrived at the server in the same tick. the first packet will grab the correct mob, set the dead flag and add a filled vial. The entity will then be scheduled for removal at next tick. However before that happens, the second packet will grab the same mob, set the dead flag again (without first checking if this entity is alive) and add another filled vial.

An ideal solution would be patch the `NetHandlerPlayServer::processUseEntity` with ASM, but that'd be a bit too tedious. This patch will simply add a `isDead` check to relevant EIO code and therefore fix the exploit mentioned in aforementioned issue. 