### PR TITLE
Initial support for channels on EnderFluidConduits

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
+import crazypants.enderio.conduit.gui.*;
 import mods.immibis.core.api.multipart.IMultipartRenderingBlockMarker;
 import mods.immibis.core.api.multipart.IMultipartSystem;
 import net.minecraft.block.Block;
@@ -51,12 +52,6 @@ import crazypants.enderio.api.tool.ITool;
 import crazypants.enderio.conduit.facade.ItemConduitFacade.FacadeType;
 import crazypants.enderio.conduit.geom.CollidableComponent;
 import crazypants.enderio.conduit.geom.ConduitConnectorType;
-import crazypants.enderio.conduit.gui.ExternalConnectionContainer;
-import crazypants.enderio.conduit.gui.GuiExternalConnection;
-import crazypants.enderio.conduit.gui.GuiExternalConnectionSelector;
-import crazypants.enderio.conduit.gui.PacketFluidFilter;
-import crazypants.enderio.conduit.gui.PacketOpenConduitUI;
-import crazypants.enderio.conduit.gui.PacketSlotVisibility;
 import crazypants.enderio.conduit.gui.item.PacketExistingItemFilterSnapshot;
 import crazypants.enderio.conduit.gui.item.PacketModItemFilter;
 import crazypants.enderio.conduit.liquid.PacketFluidLevel;
@@ -97,6 +92,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
     PacketHandler.INSTANCE.registerMessage(PacketExistingItemFilterSnapshot.class, PacketExistingItemFilterSnapshot.class, PacketHandler.nextID(), Side.SERVER);
     PacketHandler.INSTANCE.registerMessage(PacketModItemFilter.class, PacketModItemFilter.class, PacketHandler.nextID(), Side.SERVER);
     PacketHandler.INSTANCE.registerMessage(PacketFluidFilter.class, PacketFluidFilter.class, PacketHandler.nextID(), Side.SERVER);
+    PacketHandler.INSTANCE.registerMessage(PacketFluidChannel.class, PacketFluidChannel.class, PacketHandler.nextID(), Side.SERVER);
     PacketHandler.INSTANCE.registerMessage(PacketRedstoneConduitSignalColor.class, PacketRedstoneConduitSignalColor.class, PacketHandler.nextID(), Side.SERVER);
     PacketHandler.INSTANCE.registerMessage(PacketRedstoneConduitOutputStrength.class, PacketRedstoneConduitOutputStrength.class, PacketHandler.nextID(),
         Side.SERVER);

--- a/src/main/java/crazypants/enderio/conduit/gui/LiquidSettings.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/LiquidSettings.java
@@ -79,8 +79,10 @@ public class LiquidSettings extends BaseSettingsPanel {
       eConduit = (EnderLiquidConduit) con;
       isEnder = true;
 
-      int x = gui.getXSize() - 20;
+
+      int x = 52;
       int y = customTop;
+
 
       inOutNextB = MultiIconButton.createRightArrowButton(gui, NEXT_FILTER_ID, x, y);
 
@@ -94,7 +96,7 @@ public class LiquidSettings extends BaseSettingsPanel {
       gui.getContainer().setInventorySlotsVisible(false);
     }
 
-    int x = gap + gui.getFontRenderer().getStringWidth(autoExtractStr) + gap * 2;
+    int x = 66;
     int y = customTop;
 
     if(isEnder)
@@ -102,7 +104,7 @@ public class LiquidSettings extends BaseSettingsPanel {
       channelB = new ColorButton(gui, ID_CHANNEL, x, y);
       channelB.setColorIndex(0);
       channelB.setToolTipHeading(EnderIO.lang.localize("gui.conduit.item.channel"));
-      x += channelB.getWidth() + 4;
+      x += channelB.getWidth() + gap;
     }
 
     rsB = new RedstoneModeButton(gui, ID_REDSTONE_BUTTON, x, y, new IRedstoneModeControlable() {
@@ -276,11 +278,15 @@ public class LiquidSettings extends BaseSettingsPanel {
       return;
     }
 
-    channelB.onGuiInit();
-    if(isInput()){
-      channelB.setColorIndex(eConduit.getInputColor(gui.getDir()).ordinal());
+    if(conduit.getConnectionMode(gui.getDir()) == ConnectionMode.DISABLED) {
+      channelB.detach();
     } else {
-      channelB.setColorIndex(eConduit.getOutputColor(gui.getDir()).ordinal());
+      channelB.onGuiInit();
+      if (isInput()) {
+        channelB.setColorIndex(eConduit.getInputColor(gui.getDir()).ordinal());
+      } else {
+        channelB.setColorIndex(eConduit.getOutputColor(gui.getDir()).ordinal());
+      }
     }
     if(isInput()) {
       roundRobinB.onGuiInit();
@@ -337,19 +343,16 @@ public class LiquidSettings extends BaseSettingsPanel {
   @Override
   protected void renderCustomOptions(int top, float par1, int par2, int par3) {
     boolean isInput = isInput();
-    if(isInput) {
-      int x = gui.getGuiLeft() + gap + gui.getFontRenderer().getStringWidth(autoExtractStr) + gap + 2;
-      int y = top;
-      gui.getFontRenderer().drawString(autoExtractStr, left, y, ColorUtil.getRGB(Color.DARK_GRAY));
-    }
     if(isEnder && isFilterVisible()) {
-
+      String inOutStr = EnderIO.lang.localize("gui.conduit.ioMode.output");
       if(conduit.getConnectionMode(gui.getDir()) == ConnectionMode.IN_OUT) {
-        String inOutStr = inOutShowIn ? EnderIO.lang.localize("gui.conduit.ioMode.input") : EnderIO.lang.localize("gui.conduit.ioMode.output");
-        int x = gui.getGuiLeft() + gui.getXSize() - 20 - 5 - gui.getFontRenderer().getStringWidth(inOutStr);
-        int y = top;
-        gui.getFontRenderer().drawString(inOutStr, x, y, ColorUtil.getRGB(Color.DARK_GRAY));
+        inOutStr = inOutShowIn ? EnderIO.lang.localize("gui.conduit.ioMode.input") : EnderIO.lang.localize("gui.conduit.ioMode.output");
+      } else if(conduit.getConnectionMode(gui.getDir()) == ConnectionMode.INPUT){
+        inOutStr = EnderIO.lang.localize("gui.conduit.ioMode.input");
       }
+      int x = left;
+      int y = top;
+      gui.getFontRenderer().drawString(inOutStr, x, y, ColorUtil.getRGB(Color.DARK_GRAY));
 
       GL11.glColor3f(1, 1, 1);
       gui.bindGuiTexture(1);
@@ -357,8 +360,8 @@ public class LiquidSettings extends BaseSettingsPanel {
 
       FontRenderer fr = gui.getFontRenderer();
       int sw = fr.getStringWidth(filterStr);
-      int x = (gui.width / 2) - sw / 2;
-      int y = top + 20;
+      x = (gui.width / 2) - sw / 2;
+      y = top + 20;
       fr.drawString(filterStr, x, y, ColorUtil.getRGB(Color.DARK_GRAY));
 
       x = gui.getGuiLeft() + filterX;

--- a/src/main/java/crazypants/enderio/conduit/gui/LiquidSettings.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/LiquidSettings.java
@@ -187,12 +187,13 @@ public class LiquidSettings extends BaseSettingsPanel {
 
         DyeColor col = DyeColor.values()[channelB.getColorIndex()];
 
-        if(isInput()) {
+        if (isInput()) {
           eConduit.setInputColor(gui.getDir(), col);
-        } else  {
+        } else {
           eConduit.setOutputColor(gui.getDir(), col);
         }
         setConduitChannel(col);
+      }
     } else if(guiButton.id == ID_ROUND_ROBIN_BUTTON) {
       if (isEnder && isInput()) {
         final boolean selected = roundRobinB.isSelected();

--- a/src/main/java/crazypants/enderio/conduit/gui/PacketFluidChannel.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/PacketFluidChannel.java
@@ -1,0 +1,67 @@
+package crazypants.enderio.conduit.gui;
+
+import com.enderio.core.common.util.DyeColor;
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import crazypants.enderio.conduit.liquid.EnderLiquidConduit;
+import crazypants.enderio.conduit.liquid.FluidFilter;
+import crazypants.enderio.conduit.liquid.ILiquidConduit;
+import crazypants.enderio.conduit.packet.AbstractConduitPacket;
+import crazypants.enderio.conduit.packet.ConTypeEnum;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class PacketFluidChannel extends AbstractConduitPacket<ILiquidConduit> implements IMessageHandler<PacketFluidChannel, IMessage>{
+
+  private ForgeDirection dir;
+  private boolean isInput;
+
+  private DyeColor channel;
+
+  public PacketFluidChannel() {
+  }
+
+  public PacketFluidChannel(EnderLiquidConduit eConduit, ForgeDirection dir, boolean isInput, DyeColor channel) {
+    super(eConduit.getBundle().getEntity(), ConTypeEnum.FLUID);
+    this.dir = dir;
+    this.isInput = isInput;
+    this.channel = channel;
+  }
+
+  @Override
+  public void toBytes(ByteBuf buf) {
+    super.toBytes(buf);
+    buf.writeShort(dir.ordinal());
+    buf.writeBoolean(isInput);
+    buf.writeShort(channel.ordinal());
+  }
+  
+  @Override
+  public void fromBytes(ByteBuf buf) {
+    super.fromBytes(buf);
+    dir = ForgeDirection.values()[buf.readShort()];
+    isInput = buf.readBoolean();
+    channel = DyeColor.values()[buf.readShort()];
+  }
+
+  @Override
+  public IMessage onMessage(PacketFluidChannel message, MessageContext ctx) {
+    ILiquidConduit conduit = message.getTileCasted(ctx);
+    if(! (conduit instanceof EnderLiquidConduit)) {
+      return null;
+    }    
+    EnderLiquidConduit eCon = (EnderLiquidConduit)conduit;
+
+    if(message.isInput)
+      eCon.setInputColor(message.dir, message.channel);
+    else
+      eCon.setOutputColor(message.dir, message.channel);
+
+    message.getWorld(ctx).markBlockForUpdate(message.x, message.y, message.z);
+    return null;
+  }
+
+}

--- a/src/main/java/crazypants/enderio/conduit/gui/item/ItemSettings.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/item/ItemSettings.java
@@ -128,7 +128,7 @@ public class ItemSettings extends BaseSettingsPanel {
       }
     };
 
-    x += channelB.getWidth() + 4;
+    x += channelB.getWidth() + gap;
     priLeft = x - 8;
 
     rsB = new RedstoneModeButton(gui, ID_REDSTONE_BUTTON, x, y, new IRedstoneModeControlable() {
@@ -149,18 +149,18 @@ public class ItemSettings extends BaseSettingsPanel {
       }
     });
 
-    x += rsB.getWidth() + 4;
+    x += rsB.getWidth() + gap;
     colorB = new ColorButton(gui, ID_COLOR_BUTTON, x, y);
     colorB.setColorIndex(itemConduit.getExtractionSignalColor(gui.getDir()).ordinal());
     colorB.setToolTipHeading(EnderIO.lang.localize("gui.conduit.item.sigCol"));
 
-    x += 4 + colorB.getWidth();
+    x += gap + colorB.getWidth();
     roundRobinB = new ToggleButton(gui, ID_ROUND_ROBIN, x, y, IconEIO.ROUND_ROBIN_OFF, IconEIO.ROUND_ROBIN);
     roundRobinB.setSelectedToolTip(EnderIO.lang.localize("gui.conduit.item.roundRobinEnabled"));
     roundRobinB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.roundRobinDisabled"));
     roundRobinB.setPaintSelectedBorder(false);
 
-    x += 4 + roundRobinB.getWidth();
+    x += gap + roundRobinB.getWidth();
     loopB = new ToggleButton(gui, ID_LOOP, x, y, IconEIO.LOOP_OFF, IconEIO.LOOP);
     loopB.setSelectedToolTip(EnderIO.lang.localize("gui.conduit.item.selfFeedEnabled"));
     loopB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.selfFeedDisabled"));

--- a/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduit.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.enderio.core.common.util.DyeColor;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -40,6 +41,12 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
   public static final String ICON_INSERT_KEY = "enderio:liquidConduitAdvancedOutput";
   public static final String ICON_IN_OUT_KEY = "enderio:liquidConduitAdvancedInOut";
 
+  public static final String ICON_KEY_INPUT = "enderio:itemConduitInput";
+  public static final String ICON_KEY_OUTPUT = "enderio:itemConduitOutput";
+  public static final String ICON_KEY_IN_OUT_BG = "enderio:itemConduitIoConnector";
+  public static final String ICON_KEY_IN_OUT_OUT = "enderio:itemConduitInOut_Out";
+  public static final String ICON_KEY_IN_OUT_IN = "enderio:itemConduitInOut_In";
+
   static final Map<String, IIcon> ICONS = new HashMap<String, IIcon>();
 
   @SideOnly(Side.CLIENT)
@@ -53,6 +60,12 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
         ICONS.put(ICON_EXTRACT_KEY, register.registerIcon(ICON_EXTRACT_KEY));
         ICONS.put(ICON_INSERT_KEY, register.registerIcon(ICON_INSERT_KEY));
         ICONS.put(ICON_IN_OUT_KEY, register.registerIcon(ICON_IN_OUT_KEY));
+
+        ICONS.put(ICON_KEY_INPUT, register.registerIcon(ICON_KEY_INPUT));
+        ICONS.put(ICON_KEY_OUTPUT, register.registerIcon(ICON_KEY_OUTPUT));
+        ICONS.put(ICON_KEY_IN_OUT_OUT, register.registerIcon(ICON_KEY_IN_OUT_OUT));
+        ICONS.put(ICON_KEY_IN_OUT_IN, register.registerIcon(ICON_KEY_IN_OUT_IN));
+        ICONS.put(ICON_KEY_IN_OUT_BG, register.registerIcon(ICON_KEY_IN_OUT_BG));
       }
 
       @Override
@@ -68,6 +81,9 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
 
   private final EnumMap<ForgeDirection, FluidFilter> outputFilters = new EnumMap<ForgeDirection, FluidFilter>(ForgeDirection.class);
   private final EnumMap<ForgeDirection, FluidFilter> inputFilters = new EnumMap<ForgeDirection, FluidFilter>(ForgeDirection.class);
+
+  protected final EnumMap<ForgeDirection, DyeColor> outputColors = new EnumMap<ForgeDirection, DyeColor>(ForgeDirection.class);
+  protected final EnumMap<ForgeDirection, DyeColor> inputColors = new EnumMap<ForgeDirection, DyeColor>(ForgeDirection.class);
 
   @Override
   public ItemStack createItem() {
@@ -165,17 +181,21 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
   }
 
   public IIcon getTextureForInputMode() {
-    return ICONS.get(ICON_EXTRACT_KEY);
+    return ICONS.get(ICON_KEY_INPUT);
   }
 
   public IIcon getTextureForOutputMode() {
-    return ICONS.get(ICON_INSERT_KEY);
+    return ICONS.get(ICON_KEY_OUTPUT);
   }
 
-  public IIcon getTextureForInOutMode() {
-    return ICONS.get(ICON_IN_OUT_KEY);
+
+  public IIcon getTextureForInOutMode(boolean input) {
+    return input ? ICONS.get(ICON_KEY_IN_OUT_IN) : ICONS.get(ICON_KEY_IN_OUT_OUT);
   }
 
+  public IIcon getTextureForInOutBackground() {
+    return ICONS.get(ICON_KEY_IN_OUT_BG);
+  }
   @Override
   public IIcon getTransmitionTextureForState(CollidableComponent component) {
     return null;
@@ -298,10 +318,54 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
     }
     return network.getTankInfo(this, from);
   }
+  //@Override
+  public DyeColor getInputColor(ForgeDirection dir) {
+    DyeColor result = inputColors.get(dir);
+    if(result == null) {
+      return DyeColor.GREEN;
+    }
+    return result;
+  }
+
+  //@Override
+  public DyeColor getOutputColor(ForgeDirection dir) {
+    DyeColor result = outputColors.get(dir);
+    if(result == null) {
+      return DyeColor.GREEN;
+    }
+    return result;
+  }
+  //@Override
+  public void setInputColor(ForgeDirection dir, DyeColor col) {
+    inputColors.put(dir, col);
+    if(network != null) {
+      network.notifyNetworkOfUpdate();
+    }
+    setClientStateDirty();
+    collidablesDirty = true;
+  }
+
+  //@Override
+  public void setOutputColor(ForgeDirection dir, DyeColor col) {
+    outputColors.put(dir, col);
+    if(network != null) {
+      network.notifyNetworkOfUpdate();
+    }
+    setClientStateDirty();
+    collidablesDirty = true;
+  }
   
   @Override
   protected void readTypeSettings(ForgeDirection dir, NBTTagCompound dataRoot) {
     super.readTypeSettings(dir, dataRoot);
+
+    if (dataRoot.hasKey("inputColor")) {
+      setInputColor(dir, DyeColor.values()[dataRoot.getShort("inputColor")]);
+    }
+    if (dataRoot.hasKey("outputColor")) {
+      setOutputColor(dir, DyeColor.values()[dataRoot.getShort("outputColor")]);
+    }
+
     if (dataRoot.hasKey("outputFilters")) {
       FluidFilter out = new FluidFilter();
       out.readFromNBT(dataRoot.getCompoundTag("outputFilters"));
@@ -317,6 +381,10 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
   @Override
   protected void writeTypeSettingsToNbt(ForgeDirection dir, NBTTagCompound dataRoot) {
     super.writeTypeSettingsToNbt(dir, dataRoot);
+
+    dataRoot.setShort("inputColor", (short)getInputColor(dir).ordinal());
+    dataRoot.setShort("outputColor", (short)getOutputColor(dir).ordinal());
+
     FluidFilter out = outputFilters.get(dir);
     if (out != null) {
       NBTTagCompound outTag = new NBTTagCompound();
@@ -329,6 +397,7 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
       in.writeToNBT(inTag);
       dataRoot.setTag("inputFilters", inTag);
     }
+
   }
 
   @Override
@@ -354,6 +423,19 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
         }
       }
     }
+    for (Entry<ForgeDirection, DyeColor> entry : inputColors.entrySet()) {
+      if(entry.getValue() != null) {
+        short ord = (short) entry.getValue().ordinal();
+        nbtRoot.setShort("inSC." + entry.getKey().name(), ord);
+      }
+    }
+
+    for (Entry<ForgeDirection, DyeColor> entry : outputColors.entrySet()) {
+      if(entry.getValue() != null) {
+        short ord = (short) entry.getValue().ordinal();
+        nbtRoot.setShort("outSC." + entry.getKey().name(), ord);
+      }
+    }
   }
 
   @Override
@@ -377,6 +459,22 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
         f.readFromNBT(filterTag);
         if(!f.isEmpty()) {
           outputFilters.put(dir, f);
+        }
+      }
+
+      key = "inSC." + dir.name();
+      if(nbtRoot.hasKey(key)) {
+        short ord = nbtRoot.getShort(key);
+        if(ord >= 0 && ord < DyeColor.values().length) {
+          inputColors.put(dir, DyeColor.values()[ord]);
+        }
+      }
+
+      key = "outSC." + dir.name();
+      if(nbtRoot.hasKey(key)) {
+        short ord = nbtRoot.getShort(key);
+        if(ord >= 0 && ord < DyeColor.values().length) {
+          outputColors.put(dir, DyeColor.values()[ord]);
         }
       }
     }

--- a/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduit.java
@@ -9,6 +9,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.conduit.*;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.item.ItemConduit;
 import crazypants.enderio.machine.RedstoneControlMode;
 import crazypants.enderio.tool.ToolUtil;
 
@@ -33,15 +34,12 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
 
   public static final String ICON_KEY = "enderio:liquidConduitEnder";
   public static final String ICON_CORE_KEY = "enderio:liquidConduitCoreEnder";
-  public static final String ICON_EXTRACT_KEY = "enderio:liquidConduitAdvancedInput";
-  public static final String ICON_INSERT_KEY = "enderio:liquidConduitAdvancedOutput";
-  public static final String ICON_IN_OUT_KEY = "enderio:liquidConduitAdvancedInOut";
 
-  public static final String ICON_KEY_INPUT = "enderio:itemConduitInput";
-  public static final String ICON_KEY_OUTPUT = "enderio:itemConduitOutput";
-  public static final String ICON_KEY_IN_OUT_BG = "enderio:itemConduitIoConnector";
-  public static final String ICON_KEY_IN_OUT_OUT = "enderio:itemConduitInOut_Out";
-  public static final String ICON_KEY_IN_OUT_IN = "enderio:itemConduitInOut_In";
+  public static final String ICON_KEY_INPUT = ItemConduit.ICON_KEY_INPUT;
+  public static final String ICON_KEY_OUTPUT = ItemConduit.ICON_KEY_OUTPUT;
+  public static final String ICON_KEY_IN_OUT_BG = ItemConduit.ICON_KEY_IN_OUT_BG;
+  public static final String ICON_KEY_IN_OUT_OUT = ItemConduit.ICON_KEY_IN_OUT_OUT;
+  public static final String ICON_KEY_IN_OUT_IN = ItemConduit.ICON_KEY_IN_OUT_IN;
 
   static final Map<String, IIcon> ICONS = new HashMap<String, IIcon>();
 
@@ -53,9 +51,6 @@ public class EnderLiquidConduit extends AbstractLiquidConduit {
       public void registerIcons(IIconRegister register) {
         ICONS.put(ICON_KEY, register.registerIcon(ICON_KEY));
         ICONS.put(ICON_CORE_KEY, register.registerIcon(ICON_CORE_KEY));
-        ICONS.put(ICON_EXTRACT_KEY, register.registerIcon(ICON_EXTRACT_KEY));
-        ICONS.put(ICON_INSERT_KEY, register.registerIcon(ICON_INSERT_KEY));
-        ICONS.put(ICON_IN_OUT_KEY, register.registerIcon(ICON_IN_OUT_KEY));
 
         ICONS.put(ICON_KEY_INPUT, register.registerIcon(ICON_KEY_INPUT));
         ICONS.put(ICON_KEY_OUTPUT, register.registerIcon(ICON_KEY_OUTPUT));

--- a/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduitNetwork.java
@@ -94,7 +94,7 @@ public class EnderLiquidConduitNetwork extends AbstractConduitNetwork<ILiquidCon
       //TODO: Only change starting pos of iterator is doFill is true so a false then true returns the same
 
       for (NetworkTank target : getIteratorForTank(tank)) {
-        if(!target.equals(tank) && target.acceptsOuput && target.isValid() && matchedFilter(resource, target.con, target.conDir, false)) {
+        if(!target.equals(tank) && target.con.getOutputColor(target.conDir).equals(tank.con.getInputColor(tank.conDir)) && target.acceptsOuput && target.isValid() && matchedFilter(resource, target.con, target.conDir, false)) {
           int vol = target.externalTank.fill(target.tankDir, resource.copy(), doFill);
           remaining -= vol;
           filled += vol;

--- a/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduitRenderer.java
@@ -1,6 +1,9 @@
 package crazypants.enderio.conduit.liquid;
 
+import com.enderio.core.common.util.DyeColor;
+import crazypants.enderio.conduit.item.IItemConduit;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
 import crazypants.enderio.conduit.ConnectionMode;
@@ -26,19 +29,42 @@ public class EnderLiquidConduitRenderer extends DefaultConduitRenderer {
   public void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit, double x, double y, double z, float partialTick,
       float worldLight, RenderBlocks rb) {
     super.renderEntity(conduitBundleRenderer, te, conduit, x, y, z, partialTick, worldLight, rb);
+
     EnderLiquidConduit pc = (EnderLiquidConduit) conduit;
     for (ForgeDirection dir : conduit.getExternalConnections()) {
-      IIcon tex = null;
+      DyeColor inChannel = null;
+      DyeColor outChannel = null;
+      IIcon inTex = null;
+      IIcon outTex = null;
+      boolean render = true;
       if(conduit.getConnectionMode(dir) == ConnectionMode.INPUT) {
-        tex = pc.getTextureForInputMode();
+        inTex = pc.getTextureForInputMode();
+        inChannel = pc.getInputColor(dir);
       } else if(conduit.getConnectionMode(dir) == ConnectionMode.OUTPUT) {
-        tex = pc.getTextureForOutputMode();
+        outTex = pc.getTextureForOutputMode();
+        outChannel = pc.getOutputColor(dir);
       } else if(conduit.getConnectionMode(dir) == ConnectionMode.IN_OUT) {
-        tex = pc.getTextureForInOutMode();
+        inTex = pc.getTextureForInOutMode(true);
+        outTex = pc.getTextureForInOutMode(false);
+        inChannel = pc.getInputColor(dir);
+        outChannel = pc.getOutputColor(dir);
+      } else {
+        render = false;
       }
-      if(tex != null) {
+      if(render && !rb.hasOverrideBlockTexture()) {
         Offset offset = te.getOffset(ILiquidConduit.class, dir);
-        ConnectionModeGeometry.renderModeConnector(dir, offset, tex, true);
+        ConnectionModeGeometry.renderModeConnector(dir, offset, pc.getTextureForInOutBackground(), true);
+
+        if(inChannel != null) {
+          Tessellator.instance.setColorOpaque_I(inChannel.getColor());
+          ConnectionModeGeometry.renderModeConnector(dir, offset, inTex, false);
+        }
+        if(outChannel != null) {
+          Tessellator.instance.setColorOpaque_I(outChannel.getColor());
+          ConnectionModeGeometry.renderModeConnector(dir, offset, outTex, false);
+        }
+
+        Tessellator.instance.setColorOpaque_F(1f, 1f, 1f);
       }
     }
   }


### PR DESCRIPTION
This is pretty basic support for channels on ender fluid conduits. It mainly copies item conduits for gui and rendering and does the most basic check possible to match source and target before checking target filters or target acceptance.