### PR TITLE
Add round-robin button to ender conduit

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
@@ -66,6 +66,7 @@ import crazypants.enderio.conduit.packet.PacketItemConduitFilter;
 import crazypants.enderio.conduit.packet.PacketOCConduitSignalColor;
 import crazypants.enderio.conduit.packet.PacketRedstoneConduitOutputStrength;
 import crazypants.enderio.conduit.packet.PacketRedstoneConduitSignalColor;
+import crazypants.enderio.conduit.packet.PacketRoundRobinMode;
 import crazypants.enderio.conduit.redstone.IInsulatedRedstoneConduit;
 import crazypants.enderio.conduit.redstone.IRedstoneConduit;
 import crazypants.enderio.conduit.redstone.InsulatedRedstoneConduit;
@@ -104,6 +105,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
     PacketHandler.INSTANCE.registerMessage(PacketSlotVisibility.class, PacketSlotVisibility.class, PacketHandler.nextID(), Side.SERVER);
     PacketHandler.INSTANCE.registerMessage(PacketOCConduitSignalColor.class, PacketOCConduitSignalColor.class,
         PacketHandler.nextID(), Side.SERVER);
+    PacketHandler.INSTANCE.registerMessage(PacketRoundRobinMode.class, PacketRoundRobinMode.class, PacketHandler.nextID(), Side.SERVER);
 
     BlockConduitBundle result = new BlockConduitBundle();
     result.init();

--- a/src/main/java/crazypants/enderio/conduit/packet/PacketRoundRobinMode.java
+++ b/src/main/java/crazypants/enderio/conduit/packet/PacketRoundRobinMode.java
@@ -1,0 +1,47 @@
+package crazypants.enderio.conduit.packet;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import crazypants.enderio.conduit.liquid.EnderLiquidConduit;
+import crazypants.enderio.conduit.liquid.ILiquidConduit;
+import io.netty.buffer.ByteBuf;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class PacketRoundRobinMode extends AbstractConduitPacket<ILiquidConduit> implements IMessageHandler<PacketRoundRobinMode, IMessage> {
+    private ForgeDirection dir;
+    private boolean roundRobin;
+
+    public PacketRoundRobinMode() {
+    }
+
+    public PacketRoundRobinMode(EnderLiquidConduit eConduit, ForgeDirection dir) {
+        super(eConduit.getBundle().getEntity(), ConTypeEnum.FLUID);
+        this.dir = dir;
+        roundRobin = eConduit.isRoundRobin(dir);
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        super.toBytes(buf);
+        buf.writeShort(dir.ordinal());
+        buf.writeBoolean(roundRobin);
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        super.fromBytes(buf);
+        dir = ForgeDirection.values()[buf.readShort()];
+        roundRobin = buf.readBoolean();
+    }
+
+    @Override
+    public IMessage onMessage(PacketRoundRobinMode message, MessageContext ctx) {
+        final ILiquidConduit conduit = message.getTileCasted(ctx);
+        if (conduit instanceof EnderLiquidConduit) {
+            ((EnderLiquidConduit) conduit).setRoundRobin(message.dir, message.roundRobin);
+            message.getWorld(ctx).markBlockForUpdate(message.x, message.y, message.z);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
GTNewHorizons/GT-New-Horizons-Modpack#7082

This will
1. Old ender conduit will by default have round robin on, to preserve original behavior
2. New ender conduits will by default have round robin off, as a best effort attempt to minimize lag