### PR TITLE
Fix Burn Time tooltip

### DIFF
--- a/src/main/java/crazypants/enderio/gui/TooltipHandlerBurnTime.java
+++ b/src/main/java/crazypants/enderio/gui/TooltipHandlerBurnTime.java
@@ -51,7 +51,6 @@ public class TooltipHandlerBurnTime implements ITooltipCallback {
 
   @Override
   public boolean shouldHandleItem(ItemStack item) {
-    if (!Thread.currentThread().getName().startsWith("Client Thread")) return false;
     int time = TileEntityFurnace.getItemBurnTime(item);
     return time > 0 || isStirlingGen(item);
   }


### PR DESCRIPTION
Revert 3093ea6180beec8329087a1f91bda448683331d8 which broke the "Burn Time:" tooltip.  Recent enhancements to `getBurnTime` in GT, and NEI caching it should improve the CPU usage.  If it remains a problem, a cache here would be a better idea.