### PR TITLE
fix a crash with capacitor banks

### DIFF
--- a/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
@@ -409,7 +409,7 @@ public class TileCapBank extends TileEntityEio implements IInternalPowerReceiver
   @Override
   @SideOnly(Side.CLIENT)
   public AxisAlignedBB getRenderBoundingBox() {
-    if(!type.isMultiblock() || !(network instanceof CapBankClientNetwork)) {
+    if(!getType().isMultiblock() || !(network instanceof CapBankClientNetwork)) {
       return super.getRenderBoundingBox();
     }
 


### PR DESCRIPTION
type can be null in some conditions when it is accessed here, the getType() accessor should be used instead.