### PR TITLE
Optimize filter code

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/item/filter/ItemFilter.java
+++ b/src/main/java/crazypants/enderio/conduit/item/filter/ItemFilter.java
@@ -121,7 +121,7 @@ public class ItemFilter implements IInventory, IItemFilter {
     for (int i = 0; i < items.length; i++) {
       ItemStack it = items[i];
 
-      if (it != null && Item.getIdFromItem(item.getItem()) == Item.getIdFromItem(it.getItem())) {
+      if (it != null && item.getItem() == it.getItem()) {
         matched = true;
 
         if(checkDamage && !damageMatched) {


### PR DESCRIPTION
Partially address https://discord.com/channels/181078474394566657/522098956491030558/909118918705172530
There is no way to completely address this lag, as it's caused by the sheer amount of item being moved. You cannot "fix" that without kicking said player(s) out of game.