### PR TITLE
fix farming station range

### DIFF
--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -196,7 +196,7 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
     if(inventory[upg] == null) {
       return 0;
     } else {
-      return Config.farmBonusSize * EnderIO.itemBasicCapacitor.getCapacitor(inventory[upg]).getTier();
+      return Config.farmBonusSize * (EnderIO.itemBasicCapacitor.getCapacitor(inventory[upg]).getTier()-1);
     }
   }
 


### PR DESCRIPTION
before, it was using meta id as a way to detect tiers. But because this was changed to check tier of the capacitor instead, it introduced a shift in the ranges, making the double-layer capacitor working as an octadict capacitor and so on. This PR fix the shift. There could be potential shifts like that somewhere in the mod, but couldn't bother to check.