### PR TITLE
fix: moving around buttons in Big Advanced Item Filter

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/gui/item/BigItemFilterGui.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/item/BigItemFilterGui.java
@@ -74,6 +74,7 @@ public class BigItemFilterGui implements IItemFilterGui {
     useMetaB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.ignoreMetaData"));
     useMetaB.setPaintSelectedBorder(false);
 
+    y -= 20;
     stickyB = new ToggleButton(gui, ID_STICKY + buttonIdOffset, x, y, IconEIO.FILTER_STICKY_OFF, IconEIO.FILTER_STICKY);
     stickyB.setSelectedToolTip(EnderIO.lang.localizeList("gui.conduit.item.stickyEnabled"));
     stickyB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.stickyDisbaled"));
@@ -91,7 +92,7 @@ public class BigItemFilterGui implements IItemFilterGui {
     useNbtB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.ignoreNBT"));
     useNbtB.setPaintSelectedBorder(false);
 
-    y -= 20;
+    x -= 20;
     fuzzyB = new CycleButton(gui, ID_FUZZY + buttonIdOffset, x, y, FuzzyMode.class);
   }
 

--- a/src/main/java/crazypants/enderio/conduit/gui/item/BigItemFilterGui.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/item/BigItemFilterGui.java
@@ -75,12 +75,6 @@ public class BigItemFilterGui implements IItemFilterGui {
     useMetaB.setPaintSelectedBorder(false);
 
     y -= 20;
-    stickyB = new ToggleButton(gui, ID_STICKY + buttonIdOffset, x, y, IconEIO.FILTER_STICKY_OFF, IconEIO.FILTER_STICKY);
-    stickyB.setSelectedToolTip(EnderIO.lang.localizeList("gui.conduit.item.stickyEnabled"));
-    stickyB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.stickyDisbaled"));
-    stickyB.setPaintSelectedBorder(false);
-
-    y -= 20;
     useOreDictB = new ToggleButton(gui, ID_ORE_DICT + buttonIdOffset, x, y, IconEIO.FILTER_ORE_DICT_OFF, IconEIO.FILTER_ORE_DICT);
     useOreDictB.setSelectedToolTip(EnderIO.lang.localize("gui.conduit.item.oreDicEnabled"));
     useOreDictB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.oreDicDisabled"));
@@ -92,8 +86,14 @@ public class BigItemFilterGui implements IItemFilterGui {
     useNbtB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.ignoreNBT"));
     useNbtB.setPaintSelectedBorder(false);
 
-    x -= 20;
+    y -= 20;
     fuzzyB = new CycleButton(gui, ID_FUZZY + buttonIdOffset, x, y, FuzzyMode.class);
+
+    x -= 20;
+    stickyB = new ToggleButton(gui, ID_STICKY + buttonIdOffset, x, y, IconEIO.FILTER_STICKY_OFF, IconEIO.FILTER_STICKY);
+    stickyB.setSelectedToolTip(EnderIO.lang.localizeList("gui.conduit.item.stickyEnabled"));
+    stickyB.setUnselectedToolTip(EnderIO.lang.localize("gui.conduit.item.stickyDisbaled"));
+    stickyB.setPaintSelectedBorder(false);
   }
 
   public void createFilterSlots() {


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10098

Rearranged buttons in Big Advanced Item Filter to make Ignore/Match Meta Data and Sticky Mode Enabled/Disabled buttons not overlap with each other.
Before:
![image](https://user-images.githubusercontent.com/9158397/161627276-a8c03b89-2f59-4e64-a2db-af2675d99638.png)
After:
![image](https://user-images.githubusercontent.com/9158397/161627326-6b1f5808-ee9a-4149-b62d-f945430895ce.png)

