### PR TITLE
Update TileConduitBundle.java

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -166,7 +166,7 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
     if(worldObj != null && worldObj.isRemote) {
 	  boolean stableConduit = true;
 	  for(IConduit iConduit: conduits) {
-	    if ((!iConduit instanceof IItemConduit) && (!iConduit instanceof IMEConduit) && (!iConduit instanceof IOCConduit)) stableConduit = false;
+	    if (!(iConduit instanceof IItemConduit) && !(iConduit instanceof IMEConduit) && !(iConduit instanceof IOCConduit)) stableConduit = false;
 	  }
       if (stableConduit) {
         boolean itemConduitClientUpdated = false;

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -164,11 +164,15 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
     facadeMeta = nbtRoot.getInteger("facadeMeta");
 
     if(worldObj != null && worldObj.isRemote) {
-      if (conduits.size() == 1 && conduits.get(0) instanceof IItemConduit) {
+	  boolean stableConduit = true;
+	  for(IConduit iConduit: conduits) {
+	    if ((!iConduit instanceof IItemConduit) && (!iConduit instanceof IMEConduit) && (!iConduit instanceof IOCConduit)) stableConduit = false;
+	  }
+      if (stableConduit) {
         boolean itemConduitClientUpdated = false;
         for (Object o : Minecraft.getMinecraft().theWorld.playerEntities) {
           Entity e = ((Entity) o);
-          if (e.getDistanceSq(this.xCoord, yCoord, zCoord) < 36) {
+          if (e.getDistanceSq(this.xCoord, yCoord, zCoord) < 25) {
             itemConduitClientUpdated = true;
             break;
           }


### PR DESCRIPTION
--changes the logic of stable conduit, which include me and oc conduits. 

Greatly increase Client Side ItemConduit performance. (20% fps increase if have 100 - 200 item conduit in render area, these are lag-spikes.)

EnderIO Conduits are very laggy, partly because Redstone/fluid/gas Conduits causing RenderChunks re-render back and forth. But if there is only one ItemConduit in the bundle, it is pretty sure that we only need to re-render ItemConduit near the player , because only in player's behavior range (5) and the player's behavior can change the shape of ItemConduit.
But if there is another conduit in the bundle, the re-render is not sure because Redstone / liquid energy conduit in the bundle might needs to re-render in any time. So in this case I left to default.
