### PR TITLE
Fix crash when Waila is loaded and Chisel is not loaded

### DIFF
--- a/src/main/java/crazypants/util/IFacade.java
+++ b/src/main/java/crazypants/util/IFacade.java
@@ -2,8 +2,12 @@ package crazypants.util;
 
 import cofh.api.block.IBlockAppearance;
 import cpw.mods.fml.common.Optional;
+import net.minecraft.block.Block;
+import net.minecraft.world.IBlockAccess;
 
 @Optional.Interface(modid = "chisel", iface = "com.cricketcraft.chisel.api.IFacade")
 public interface IFacade extends com.cricketcraft.chisel.api.IFacade, IBlockAppearance {
-    // :(
+    Block getFacade(IBlockAccess world, int x, int y, int z, int side);
+
+    int getFacadeMetadata(IBlockAccess world, int x, int y, int z, int side);
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10822
I'm not sure if this is the right way, but works for both when Chisel is loaded and not loaded.