### PR TITLE
collapse continuous glPushAttrib into one call

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/render/ConduitBundleRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/ConduitBundleRenderer.java
@@ -71,8 +71,7 @@ public class ConduitBundleRenderer extends TileEntitySpecialRenderer implements 
 
                         RenderUtil.bindBlockTexture();
 
-                        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
-                        GL11.glPushAttrib(GL11.GL_LIGHTING_BIT);
+                        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_LIGHTING_BIT);
                         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
                         GL11.glEnable(GL11.GL_BLEND);
                         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
@@ -93,7 +92,6 @@ public class ConduitBundleRenderer extends TileEntitySpecialRenderer implements 
 
             GL11.glShadeModel(GL11.GL_FLAT);
             GL11.glPopMatrix();
-            GL11.glPopAttrib();
             GL11.glPopAttrib();
         }
     }

--- a/src/main/java/crazypants/enderio/machine/capbank/GuiCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/GuiCapBank.java
@@ -282,10 +282,8 @@ public class GuiCapBank extends GuiContainerBaseEIO {
     @SuppressWarnings("rawtypes")
     @Override
     public void drawHoveringText(List par1List, int par2, int par3, FontRenderer font) {
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
-        GL11.glPushAttrib(GL11.GL_LIGHTING_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_LIGHTING_BIT);
         super.drawHoveringText(par1List, par2 + 24, par3, font);
-        GL11.glPopAttrib();
         GL11.glPopAttrib();
     }
 

--- a/src/main/java/crazypants/enderio/machine/hypercube/GuiHyperCube.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/GuiHyperCube.java
@@ -405,10 +405,8 @@ public class GuiHyperCube extends GuiContainerBaseEIO {
 
     @Override
     public void drawHoveringText(List par1List, int par2, int par3, FontRenderer font) {
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
-        GL11.glPushAttrib(GL11.GL_LIGHTING_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_LIGHTING_BIT);
         super.drawHoveringText(par1List, par2, par3, font);
-        GL11.glPopAttrib();
         GL11.glPopAttrib();
     }
 

--- a/src/main/java/crazypants/enderio/machine/power/GuiCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/GuiCapacitorBank.java
@@ -295,10 +295,8 @@ public class GuiCapacitorBank extends GuiContainerBaseEIO {
 
     @Override
     public void drawHoveringText(List par1List, int par2, int par3, FontRenderer font) {
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
-        GL11.glPushAttrib(GL11.GL_LIGHTING_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_LIGHTING_BIT);
         super.drawHoveringText(par1List, par2 + 24, par3, font);
-        GL11.glPopAttrib();
         GL11.glPopAttrib();
     }
 

--- a/src/main/java/crazypants/enderio/teleport/anchor/TravelEntitySpecialRenderer.java
+++ b/src/main/java/crazypants/enderio/teleport/anchor/TravelEntitySpecialRenderer.java
@@ -80,8 +80,7 @@ public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
         Minecraft.getMinecraft().entityRenderer.disableLightmap(0);
 
         RenderUtil.bindBlockTexture();
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
-        GL11.glPushAttrib(GL11.GL_LIGHTING_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_LIGHTING_BIT);
 
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 
@@ -115,7 +114,6 @@ public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
 
         renderLabel(tileentity, x, y, z, ta, sf);
 
-        GL11.glPopAttrib();
         GL11.glPopAttrib();
 
         Minecraft.getMinecraft().entityRenderer.enableLightmap(0);


### PR DESCRIPTION
I might not be a OpenGL expert, but I do know these calls are somewhat expensive and should not be called like that.
