### PR TITLE
Solar Panels: Use config for capacity RF

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -288,6 +288,10 @@ public final class Config {
     public static int maxPhotovoltaicAdvancedOutputRF = 40;
     public static int maxPhotovoltaicVibrantOutputRF = 160;
 
+    public static int photovoltaicCellCapacityRF = 10000;
+    public static int photovoltaicAdvancedCellCapacityRF = 10000;
+    public static int photovoltaicVibrantCellCapacityRF = 10000;
+
     public static int zombieGeneratorRfPerTick = 80;
     public static int zombieGeneratorTicksPerBucketFuel = 12000;
 
@@ -807,6 +811,28 @@ public final class Config {
                         maxPhotovoltaicVibrantOutputRF,
                         "Maximum output in RF/t of the Vibrant Photovoltaic Panels.")
                 .getInt(maxPhotovoltaicVibrantOutputRF);
+                
+        photovoltaicCellCapacityRF = config
+                .get(
+                        sectionPower.name,
+                        "photovoltaicCellCapacityRF",
+                        photovoltaicCellCapacityRF,
+                        "Maximum capacity in RF/t of the Photovoltaic Panels.")
+                .getInt(photovoltaicCellCapacityRF);
+        photovoltaicAdvancedCellCapacityRF = config
+                .get(
+                        sectionPower.name,
+                        "photovoltaicAdvancedCellCapacityRF",
+                        photovoltaicAdvancedCellCapacityRF,
+                        "Maximum capacity in RF/t of the Advanced Photovoltaic Panels.")
+                .getInt(photovoltaicAdvancedCellCapacityRF);
+        photovoltaicVibrantCellCapacityRF = config
+                .get(
+                        sectionPower.name,
+                        "photovoltaicVibrantCellCapacityRF",
+                        photovoltaicVibrantCellCapacityRF,
+                        "Maximum capacity in RF/t of the Vibrant Photovoltaic Panels.")
+                .getInt(photovoltaicVibrantCellCapacityRF);
 
         useAlternateBinderRecipe = config
                 .get(

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -811,14 +811,12 @@ public final class Config {
                         maxPhotovoltaicVibrantOutputRF,
                         "Maximum output in RF/t of the Vibrant Photovoltaic Panels.")
                 .getInt(maxPhotovoltaicVibrantOutputRF);
-                
-        photovoltaicCellCapacityRF = config
-                .get(
-                        sectionPower.name,
-                        "photovoltaicCellCapacityRF",
-                        photovoltaicCellCapacityRF,
-                        "Maximum capacity in RF/t of the Photovoltaic Panels.")
-                .getInt(photovoltaicCellCapacityRF);
+
+        photovoltaicCellCapacityRF = config.get(
+                sectionPower.name,
+                "photovoltaicCellCapacityRF",
+                photovoltaicCellCapacityRF,
+                "Maximum capacity in RF/t of the Photovoltaic Panels.").getInt(photovoltaicCellCapacityRF);
         photovoltaicAdvancedCellCapacityRF = config
                 .get(
                         sectionPower.name,

--- a/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
+++ b/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
@@ -98,18 +98,20 @@ public class SolarPanelNetwork {
 
     private static int getCapacity(TileEntitySolarPanel panel, int panelsCount) {
         int capacity = ENERGY_PER;
-        int meta = panel.getBlockMetadata();
 
-        switch (meta) {
-            case 0: // Default
-                capacity = Config.photovoltaicCellCapacityRF;
-                break;
-            case 1: // Advanced
-                capacity = Config.photovoltaicAdvancedCellCapacityRF;
-                break;
-            case 2: // Vibrant
-                capacity = Config.photovoltaicVibrantCellCapacityRF;
-                break;
+        if (panel != null) {
+            int meta = panel.getBlockMetadata();
+            switch (meta) {
+                case 0: // Default
+                    capacity = Config.photovoltaicCellCapacityRF;
+                    break;
+                case 1: // Advanced
+                    capacity = Config.photovoltaicAdvancedCellCapacityRF;
+                    break;
+                case 2: // Vibrant
+                    capacity = Config.photovoltaicVibrantCellCapacityRF;
+                    break;
+            }
         }
 
         capacity = capacity * panelsCount;

--- a/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
+++ b/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
@@ -32,6 +32,7 @@ public class SolarPanelNetwork {
     SolarPanelNetwork(TileEntitySolarPanel initial) {
         this();
         panels.add(initial);
+        energy.setCapacity(getCapacity(initial, 1));
         empty = false;
     }
 
@@ -89,22 +90,29 @@ public class SolarPanelNetwork {
 
         if (panels.size() > 0) {
             TileEntitySolarPanel masterPanel = getMaster();
-            int meta = masterPanel.getBlockMetadata();
-
-            switch (meta) {
-                case 0: // Default
-                    capacity = Config.photovoltaicCellCapacityRF;
-                    break;
-                case 1: // Advanced
-                    capacity = Config.photovoltaicAdvancedCellCapacityRF;
-                    break;
-                case 2: // Vibrant
-                    capacity = Config.photovoltaicVibrantCellCapacityRF;
-                    break;
-            }
-
-            capacity = capacity * panels.size();
+            capacity = getCapacity(masterPanel, panels.size());
         }
+
+        return capacity;
+    }
+
+    private static int getCapacity(TileEntitySolarPanel panel, int panelsCount) {
+        int capacity = ENERGY_PER;
+        int meta = panel.getBlockMetadata();
+
+        switch (meta) {
+            case 0: // Default
+                capacity = Config.photovoltaicCellCapacityRF;
+                break;
+            case 1: // Advanced
+                capacity = Config.photovoltaicAdvancedCellCapacityRF;
+                break;
+            case 2: // Vibrant
+                capacity = Config.photovoltaicVibrantCellCapacityRF;
+                break;
+        }
+
+        capacity = capacity * panelsCount;
 
         return capacity;
     }

--- a/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
+++ b/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
@@ -8,9 +8,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import cofh.api.energy.EnergyStorage;
-import crazypants.enderio.config.Config;
 
 import com.google.common.collect.Lists;
+import crazypants.enderio.config.Config;
 
 public class SolarPanelNetwork {
 
@@ -84,14 +84,14 @@ public class SolarPanelNetwork {
         destroyNetwork();
     }
 
-    private int getCapacity(){
+    private int getCapacity() {
         int capacity = ENERGY_PER;
 
-        if (panels.size() > 0){
+        if (panels.size() > 0) {
             TileEntitySolarPanel masterPanel = getMaster();
             int meta = masterPanel.getBlockMetadata();
 
-            switch(meta) {
+            switch (meta) {
                 case 0: // Default
                     capacity = Config.photovoltaicCellCapacityRF;
                     break;

--- a/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
+++ b/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
@@ -8,6 +8,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import cofh.api.energy.EnergyStorage;
+import crazypants.enderio.config.Config;
 
 import com.google.common.collect.Lists;
 
@@ -25,7 +26,7 @@ public class SolarPanelNetwork {
 
     public SolarPanelNetwork() {
         panels = Lists.newArrayList();
-        energy = new EnergyStorage(ENERGY_PER);
+        energy = new EnergyStorage(getCapacity());
     }
 
     SolarPanelNetwork(TileEntitySolarPanel initial) {
@@ -83,8 +84,33 @@ public class SolarPanelNetwork {
         destroyNetwork();
     }
 
+    private int getCapacity(){
+        int capacity = ENERGY_PER;
+
+        if (panels.size() > 0){
+            TileEntitySolarPanel masterPanel = getMaster();
+            int meta = masterPanel.getBlockMetadata();
+
+            switch(meta) {
+                case 0: // Default
+                    capacity = Config.photovoltaicCellCapacityRF;
+                    break;
+                case 1: // Advanced
+                    capacity = Config.photovoltaicAdvancedCellCapacityRF;
+                    break;
+                case 2: // Vibrant
+                    capacity = Config.photovoltaicVibrantCellCapacityRF;
+                    break;
+            }
+
+            capacity = capacity * panels.size();
+        }
+
+        return capacity;
+    }
+
     private void updateEnergy() {
-        energy.setCapacity(ENERGY_PER * panels.size());
+        energy.setCapacity(getCapacity());
         energy.setMaxExtract(energy.getMaxEnergyStored());
     }
 


### PR DESCRIPTION
While you can configure the max output RF of solar panals, it would be useful to configure the max storable energy aswell to scale it with the max output RF. This PR fixes it (tested).
Default value for all solar panels is 10000 RF (as before).

#### My use-case within my modpack
- Solar Panel
  - Max Out: 100 RF
  - Capacity: 10000 RF
- Advanced Solar Panel
  - Max Out: 1000 RF
  - Capacity: 100000 RF
- Vibrant Solar Panel
  - Max Out: 10000 RF
  - Capacity: 1000000 RF

As you can see, with 10000 RF output the max capacity of 10000 is a hard limit (in several aspects).

#### Pictures from tests (only capacity adjusted)
![grafik](https://user-images.githubusercontent.com/23138465/217448685-3c502525-29d0-4d58-b3b4-75280d560241.png)
![grafik](https://user-images.githubusercontent.com/23138465/217448170-00ce8435-d070-441b-9db4-b0a1e456f985.png)
![grafik](https://user-images.githubusercontent.com/23138465/217448200-af1393a4-9e8a-4740-97fd-9bf82d89f94d.png)
![grafik](https://user-images.githubusercontent.com/23138465/217448108-7b47681c-883a-4d27-aabb-e0d265f4e27a.png)
![grafik](https://user-images.githubusercontent.com/23138465/217448129-2f24fde4-16cf-406e-a1b9-3057d861f049.png)
![grafik](https://user-images.githubusercontent.com/23138465/217448040-ba31dae1-b0d7-4bd5-a580-4a19b0e911a9.png)
![grafik](https://user-images.githubusercontent.com/23138465/217448066-f4a84636-a3a3-4aa5-b761-2cee15b74c83.png)

