### PR TITLE
Fix Waila tooltip for Endergy Energy Conduits

### DIFF
--- a/src/main/java/crazypants/enderio/waila/WailaCompat.java
+++ b/src/main/java/crazypants/enderio/waila/WailaCompat.java
@@ -301,7 +301,7 @@ public class WailaCompat implements IWailaDataProvider {
             return;
         }
 
-        if (itemStack.getItem() == EnderIO.itemPowerConduit) {
+        if (itemStack.getItem() == EnderIO.itemPowerConduit || itemStack.getItem() == EnderIO.itemPowerConduitEndergy) {
             NBTTagCompound nbtRoot = _accessor.getNBTData();
             if (nbtRoot.hasKey("storedEnergyRF")) {
                 int stored = nbtRoot.getInteger("storedEnergyRF");


### PR DESCRIPTION
It's another item, that's why it's not shown. With this change, it shows the used/max energy now:
![grafik](https://user-images.githubusercontent.com/23138465/217462451-be91834f-51c0-49dc-9fbd-b5ac2b57ef1b.png)
