### PR TITLE
Fix for `getTravelItemTravelSource`

### DIFF
--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -554,8 +554,8 @@ public class TravelController {
             return null;
         }
         ItemStack equipped = ep.getCurrentEquippedItem();
-        if (equipped.getItem() instanceof ItemTravelStaff) {
-            if (((ItemTravelStaff) equipped.getItem()).isActive(ep, equipped)) {
+        if (equipped.getItem() instanceof ItemTeleportStaff) {
+            if (((ItemTeleportStaff) equipped.getItem()).isActive(ep, equipped)) {
                 return TravelSource.TELEPORT_STAFF;
             }
         } else if (equipped.getItem() instanceof IItemOfTravel) {


### PR DESCRIPTION
This bug does not currently have any gameplay effect, because the return value of this method is not used to determine teleport range. But we should fix it anyway.