### PR TITLE
Fix NullReferenceException at getCapacity->getBlockMetadata

### DIFF
--- a/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
+++ b/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
@@ -96,10 +96,10 @@ public class SolarPanelNetwork {
         return capacity;
     }
 
-    private static int getCapacity(TileEntitySolarPanel panel, int panelsCount) {
+    private int getCapacity(TileEntitySolarPanel panel, int panelsCount) {
         int capacity = ENERGY_PER;
 
-        if (panel != null) {
+        if (panel != null && panel.hasWorldObj()) {
             int meta = panel.getBlockMetadata();
             switch (meta) {
                 case 0: // Default

--- a/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
+++ b/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
@@ -96,7 +96,7 @@ public class SolarPanelNetwork {
         return capacity;
     }
 
-    private int getCapacity(TileEntitySolarPanel panel, int panelsCount) {
+    private static int getCapacity(TileEntitySolarPanel panel, int panelsCount) {
         int capacity = ENERGY_PER;
 
         if (panel != null && panel.hasWorldObj()) {


### PR DESCRIPTION
It's not critical at all but I've found this little missing check after one of my previous PRs got merged.

**Before:** Error message in Server Console without any effect to the functionality at loading a solar panel's data.
**After:** No error message.