### PR TITLE
Apply max capacity config also for single solar cells without network

### DIFF
--- a/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
+++ b/src/main/java/crazypants/enderio/machine/solar/SolarPanelNetwork.java
@@ -18,6 +18,7 @@ public class SolarPanelNetwork {
     private boolean empty = true;
 
     private EnergyStorage energy;
+    private boolean hasAppliedMaxEnergyConfig = false;
 
     public static final int ENERGY_PER = 10000;
 
@@ -96,7 +97,7 @@ public class SolarPanelNetwork {
         return capacity;
     }
 
-    private static int getCapacity(TileEntitySolarPanel panel, int panelsCount) {
+    private int getCapacity(TileEntitySolarPanel panel, int panelsCount) {
         int capacity = ENERGY_PER;
 
         if (panel != null && panel.hasWorldObj()) {
@@ -112,11 +113,18 @@ public class SolarPanelNetwork {
                     capacity = Config.photovoltaicVibrantCellCapacityRF;
                     break;
             }
+            hasAppliedMaxEnergyConfig = true;
         }
 
         capacity = capacity * panelsCount;
 
         return capacity;
+    }
+
+    private void updateEnergyIfNeeded() {
+        if (!hasAppliedMaxEnergyConfig) {
+            updateEnergy();
+        }
     }
 
     private void updateEnergy() {
@@ -155,6 +163,7 @@ public class SolarPanelNetwork {
     }
 
     public int setEnergyStored(int energy) {
+        updateEnergyIfNeeded();
         if (isValid()) {
             this.energy.setEnergyStored(energy);
         }


### PR DESCRIPTION
My previous PR #97 fixes a null reference exception but as side effect it prevents single solar cells to re-try to apply the correct config at a later time when they actually have a network. This PR corrects it, the solar cells are working 100%ly correct now.