### PR TITLE
Improve canConnectToExternal()

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
@@ -84,6 +84,8 @@ public abstract class AbstractConduit implements IConduit {
 
     protected boolean connectionsDirty = true;
 
+    protected boolean needUpdateConnections = false;
+
     protected AbstractConduit() {}
 
     @Override
@@ -461,7 +463,15 @@ public abstract class AbstractConduit implements IConduit {
             connectionsChanged();
         }
 
-        connectionsDirty = false;
+        if (needUpdateConnections) {
+            needUpdateConnections = false;
+        } else {
+            connectionsDirty = false;
+        }
+    }
+
+    protected void needUpdateConnections() {
+        needUpdateConnections = true;
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -174,6 +174,9 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
                 if (node == null) {
                     node = part.getGridNode();
                 }
+                if (node == null) {
+                    return !isDenseUltra();
+                }
             }
         } else if (te instanceof IGridHost) {
             node = ((IGridHost) te).getGridNode(dir.getOpposite());

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -175,7 +175,7 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
                     node = part.getGridNode();
                 }
                 if (node == null) {
-                    return !isDenseUltra();
+                    needUpdateConnections();
                 }
             }
         } else if (te instanceof IGridHost) {


### PR DESCRIPTION
Fixes a case where at loading the Grid sometimes the conduits may not connect.
I've tested this case with all conduit types and all me cables and some buses and mashines, still work as it should.

Before:
![grafik](https://user-images.githubusercontent.com/23138465/226723353-0b82ae98-dde5-4994-8e37-b7a16eb13a2b.png)

After:
![grafik](https://user-images.githubusercontent.com/23138465/226723373-11e3a79d-5ea9-4d76-b232-b5bd659942bf.png)
