### PR TITLE
Add comments for `needUpdateConnections`

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
@@ -84,6 +84,14 @@ public abstract class AbstractConduit implements IConduit {
 
     protected boolean connectionsDirty = true;
 
+    /**
+     * This shows if the currently running connection update should not finish with settings connectionsDirty to false.
+     * If this is true, it will trigger a reconnection on the next Tick.
+     * <p>
+     * Use the method needUpdateConnections() instead of setting this to true.
+     * 
+     * @see needUpdateConnections()
+     */
     protected boolean needUpdateConnections = false;
 
     protected AbstractConduit() {}
@@ -464,12 +472,21 @@ public abstract class AbstractConduit implements IConduit {
         }
 
         if (needUpdateConnections) {
+            // Seems the update was not successfull, let's try on the next Tick.
             needUpdateConnections = false;
         } else {
             connectionsDirty = false;
         }
     }
 
+    /**
+     * This method prevents connection update from getting completed successfully by not settings connectionsDirty to
+     * false. This will trigger an connection update at the next Tick.
+     * <p>
+     * Only use this while executing updateConnections().
+     * <p>
+     * See this PR for more info: https://github.com/GTNewHorizons/EnderIO/pull/111
+     */
     protected void needUpdateConnections() {
         needUpdateConnections = true;
     }

--- a/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
@@ -84,6 +84,8 @@ public abstract class AbstractConduit implements IConduit {
 
     protected boolean connectionsDirty = true;
 
+    protected boolean needUpdateConnections = false;
+
     protected AbstractConduit() {}
 
     @Override
@@ -461,7 +463,15 @@ public abstract class AbstractConduit implements IConduit {
             connectionsChanged();
         }
 
-        connectionsDirty = false;
+        if (needUpdateConnections) {
+            needUpdateConnections = false;
+        } else {
+            connectionsDirty = false;
+        }
+    }
+
+    protected void needUpdateConnections() {
+        needUpdateConnections = true;
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -175,6 +175,7 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
                     node = part.getGridNode();
                 }
                 if (node == null) {
+                    // The GridNode has not been initialized yet, let's try on the next Tick.
                     needUpdateConnections();
                 }
             }

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -174,6 +174,9 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
                 if (node == null) {
                     node = part.getGridNode();
                 }
+                if (node == null) {
+                    return !isDenseUltra();
+                }
             }
         } else if (te instanceof IGridHost) {
             node = ((IGridHost) te).getGridNode(dir.getOpposite());

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -175,7 +175,7 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
                     node = part.getGridNode();
                 }
                 if (node == null) {
-                    return !isDenseUltra();
+                    needUpdateConnections();
                 }
             }
         } else if (te instanceof IGridHost) {


### PR DESCRIPTION
Adds comments to the method and field `AbstractConduit.needUpdateConnections` and also at the call at `MEConduit.canConnectToExternal`.

Squash and merge recommended (messed up the history in my master).