### PR TITLE
`needUpdateConnections` only while updating cons

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
@@ -92,7 +92,9 @@ public abstract class AbstractConduit implements IConduit {
      * 
      * @see needUpdateConnections()
      */
-    protected boolean needUpdateConnections = false;
+    private boolean needUpdateConnections = false;
+
+    private boolean isUpdatingConnections = false;
 
     protected AbstractConduit() {}
 
@@ -444,9 +446,12 @@ public abstract class AbstractConduit implements IConduit {
     }
 
     private void updateConnections() {
-        if (!connectionsDirty) {
+        if (!connectionsDirty && !needUpdateConnections) {
             return;
         }
+
+        isUpdatingConnections = true;
+        needUpdateConnections = false;
 
         boolean externalConnectionsChanged = false;
         List<ForgeDirection> copy = new ArrayList<ForgeDirection>(externalConnections);
@@ -471,12 +476,8 @@ public abstract class AbstractConduit implements IConduit {
             connectionsChanged();
         }
 
-        if (needUpdateConnections) {
-            // Seems the update was not successfull, let's try on the next Tick.
-            needUpdateConnections = false;
-        } else {
-            connectionsDirty = false;
-        }
+        connectionsDirty = false;
+        isUpdatingConnections = false;
     }
 
     /**
@@ -488,7 +489,9 @@ public abstract class AbstractConduit implements IConduit {
      * See this PR for more info: https://github.com/GTNewHorizons/EnderIO/pull/111
      */
     protected void needUpdateConnections() {
-        needUpdateConnections = true;
+        if (isUpdatingConnections) {
+            needUpdateConnections = true;
+        }
     }
 
     @Override


### PR DESCRIPTION
After the latest commit yesterday we had massive lag spikes on your prod server, specifically when interacting with the ME . I was not able to detect with Opis, but this PR seems to fix the issue.

Basically this change doesn't affect the functionality but only allows a re-try while `updateConnections()` is executed and make the code looking minimal better.

@repo-alt @eigenraven (or anyone that knows the answer)
Can you ensure to 100% that a Part can NEVER live without a GridNode forever? Or could there be the case that a Part never gets a GridNode (for any reason)?
And also, how many ticks should it take maximal for the whole Grid and all Parts to initialize? Is that always done on one single tick or does it depend on the amount of Parts and Grid elements?

I need to know that because then I can decide to either keep the new code here as it is and allow a infinite loop (calling updateConnections() on each single Tick) OR if I should add a counter and only allow maximal X retries.