### PR TITLE
Try to fix energy overflow

### DIFF
--- a/src/main/java/crazypants/enderio/item/ItemMagnet.java
+++ b/src/main/java/crazypants/enderio/item/ItemMagnet.java
@@ -131,6 +131,10 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
 
     @Override
     public int receiveEnergy(ItemStack container, int maxReceive, boolean simulate) {
+        if (maxReceive < 0) {
+            return 0;
+        }
+
         int res = super.receiveEnergy(container, maxReceive, simulate);
         if (res != 0 && !simulate) {
             updateDamage(container);
@@ -148,6 +152,10 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     }
 
     public int extractEnergyInternal(ItemStack container, int maxExtract, boolean simulate) {
+        if (maxExtract < 0) {
+            return 0;
+        }
+
         int res = super.extractEnergy(container, maxExtract, simulate);
         if (res != 0 && !simulate) {
             updateDamage(container);

--- a/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
@@ -68,6 +68,12 @@ public class ItemTeleportStaff extends ItemTravelStaff {
     }
 
     @Override
+    public int receiveEnergy(ItemStack container, int maxReceive, boolean simulate) {
+        // Don't allow receiving energy, since we have infinite energy.
+        return 0;
+    }
+
+    @Override
     public int extractEnergy(ItemStack container, int maxExtract, boolean simulate) {
         // Don't allow extracting energy.
         return 0;

--- a/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
@@ -103,6 +103,10 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
 
     @Override
     public int receiveEnergy(ItemStack container, int maxReceive, boolean simulate) {
+        if (maxReceive < 0) {
+            return 0;
+        }
+
         int res = super.receiveEnergy(container, maxReceive, simulate);
         if (res != 0 && !simulate) {
             updateDamage(container);
@@ -112,6 +116,10 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
 
     @Override
     public int extractEnergy(ItemStack container, int maxExtract, boolean simulate) {
+        if (maxExtract < 0) {
+            return 0;
+        }
+
         int res = super.extractEnergy(container, maxExtract, simulate);
         if (res != 0 && !simulate) {
             updateDamage(container);


### PR DESCRIPTION
I think I've seen a few reports of the Ender IO staff of traveling and staff of teleportation somehow getting set to IIRC, near `Integer.MIN_VALUE` amount of stored energy. Reading through the code, the only way I could see for this to happen was if `receiveEnergy` or `extractEnergy` was called with a very negative number.

If I'm right about the cause, then this PR will fix the symptoms for Ender IO, but it won't fix the underlying issue that we have code somewhere which occasionally overflows and calls `receiveEnergy` or (less likely) `extractEnergy` with, I'm guessing, a value near `Integer.MIN_VALUE`, and any other mods that contain subclasses of `ItemEnergyContainer` may still be affected by the issue.

I don't know much about mix-ins, but we could also try putting these checks directly into `cofh.api.energy.ItemEnergyContainer`.