### PR TITLE
prevent ghostloading

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/ConduitUtil.java
+++ b/src/main/java/crazypants/enderio/conduit/ConduitUtil.java
@@ -248,7 +248,7 @@ public class ConduitUtil {
 
     public static <T extends IConduit> Collection<T> getConnectedConduits(World world, int x, int y, int z,
             Class<T> type) {
-        TileEntity te = world.getTileEntity(x, y, z);
+        TileEntity te = world.blockExists(x, y, z) ? world.getTileEntity(x, y, z) : null;
         if (!(te instanceof IConduitBundle)) {
             return Collections.emptyList();
         }

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -155,7 +155,16 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
     public boolean canConnectToExternal(ForgeDirection dir, boolean ignoreDisabled) {
         World world = getBundle().getWorld();
         BlockCoord pos = getLocation();
-        TileEntity te = world.getTileEntity(pos.x + dir.offsetX, pos.y + dir.offsetY, pos.z + dir.offsetZ);
+
+        final int exactPosX = pos.x + dir.offsetX;
+        final int exactPosY = pos.y + dir.offsetY;
+        final int exactPosZ = pos.z + dir.offsetZ;
+        
+        if (!world.blockExists(exactPosX, exactPosY, exactPosZ)) {
+            return false;
+        }
+
+        TileEntity te = world.getTileEntity(exactPosX, exactPosY, exactPosZ);
 
         if (te instanceof TileConduitBundle) {
             return false;

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -314,7 +314,11 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
     private void onNodeChanged(BlockCoord location) {
         World world = getBundle().getWorld();
         for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
-            TileEntity te = location.getLocation(dir).getTileEntity(world);
+            BlockCoord dirLocation = location.getLocation(dir);
+            TileEntity te = null;
+            if (world.blockExists(dirLocation.x, dirLocation.y, dirLocation.z)) {
+                te = location.getLocation(dir).getTileEntity(world);
+            }
             if (te != null && te instanceof IGridHost && !(te instanceof IConduitBundle)) {
                 IGridNode node = ((IGridHost) te).getGridNode(ForgeDirection.UNKNOWN);
                 if (node == null) {
@@ -330,7 +334,12 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
     @Override
     public void onAddedToBundle() {
         for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
-            TileEntity te = getLocation().getLocation(dir).getTileEntity(getBundle().getWorld());
+            World world = getBundle().getWorld();
+            BlockCoord dirLocation = getLocation().getLocation(dir);
+            TileEntity te = null;
+            if (world.blockExists(dirLocation.x, dirLocation.y, dirLocation.z)) {
+                te = dirLocation.getTileEntity(world);
+            }
             if (te instanceof TileConduitBundle) {
                 IMEConduit cond = ((TileConduitBundle) te).getConduit(IMEConduit.class);
                 if (cond != null) {

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -159,7 +159,7 @@ public class MEConduit extends AbstractConduit implements IMEConduit {
         final int exactPosX = pos.x + dir.offsetX;
         final int exactPosY = pos.y + dir.offsetY;
         final int exactPosZ = pos.z + dir.offsetZ;
-        
+
         if (!world.blockExists(exactPosX, exactPosY, exactPosZ)) {
             return false;
         }


### PR DESCRIPTION
Here the final fix for ME Conduits ghostloading. This time real, not sure how I didn't see this before, but thanks to repo-alt's change to AE2Stuff I had an idea for what I could search.

Is it ok to store the position + offset in variables? I don't like that long line twice. But just tell me. :)

Similar to https://github.com/GTNewHorizons/ae2stuff/pull/8

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12534