### PR TITLE
Fix generating UserIdent for offline worlds

### DIFF
--- a/src/main/java/crazypants/util/UserIdent.java
+++ b/src/main/java/crazypants/util/UserIdent.java
@@ -6,11 +6,16 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.UsernameCache;
 
 import com.enderio.core.common.util.PlayerUtil;
 import com.google.common.base.Charsets;
 import com.mojang.authlib.GameProfile;
+
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.server.FMLServerHandler;
 import crazypants.enderio.Log;
 
 public class UserIdent {
@@ -109,8 +114,7 @@ public class UserIdent {
      */
     public static @Nonnull UserIdent create(@Nullable GameProfile gameProfile) {
         if (gameProfile != null && (gameProfile.getId() != null || gameProfile.getName() != null)) {
-            if (gameProfile.getId() != null && gameProfile.getName() != null
-                    && gameProfile.getId().equals(offlineUUID(gameProfile.getName()))) {
+            if (gameProfile.getName() != null && !isOnlineMode()) {
                 return new UserIdent(null, gameProfile.getName());
             } else {
                 return new UserIdent(gameProfile.getId(), gameProfile.getName());
@@ -118,6 +122,17 @@ public class UserIdent {
         } else {
             return nobody;
         }
+    }
+
+    private static boolean isOnlineMode() {
+        MinecraftServer server;
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            server = FMLServerHandler.instance().getServer();
+        }
+        else {
+            server = FMLClientHandler.instance().getServer();
+        }
+        return server.isServerInOnlineMode();
     }
 
     private static @Nonnull UUID offlineUUID(String playerName) {

--- a/src/main/java/crazypants/util/UserIdent.java
+++ b/src/main/java/crazypants/util/UserIdent.java
@@ -128,8 +128,7 @@ public class UserIdent {
         MinecraftServer server;
         if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
             server = FMLServerHandler.instance().getServer();
-        }
-        else {
+        } else {
             server = FMLClientHandler.instance().getServer();
         }
         return server.isServerInOnlineMode();


### PR DESCRIPTION
The current condition to check for offline UUID isn't valid anymore as the UUID is never null here. It's always an UUID for "PlayerName" but Ender IO expect and checks for an UUID for "GameProfile:Pilzinsel64".

This PR fixes this by checking if the server is running in offline mode and uses this as indicator to create the `UserIdent` with or without an (online-)UUID.

The check is done each time it is needed. Reason is because you can set the online mode while the server is running. So it could change while the server is running.

Sadly I didn't find a way to check the user behind the GameProfile directly. For any suggestions, just tell me. :)

But anyways, this works better then before (before = not working at all).

Background story: I just figured out that my Dimensational Transceiver stored all my private channels with an unexpected UUID. I know my offline UUID and my server runs in offline mode. So I expect the channel to be saved either with my offline UUID or (how the code tells you) with `none`.