### PR TITLE
Use config for transceiver's energy buffer

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -101,6 +101,7 @@ public final class Config {
     public static int transceiverUpkeepCostRF = 10;
     public static int transceiverBucketTransmissionCostRF = 100;
     public static int transceiverMaxIoRF = 20480;
+    public static int transceiverInternalBuffer = 500000;
     public static boolean transceiverUseEasyRecipe = false;
 
     public static File configDirectory;
@@ -1002,6 +1003,13 @@ public final class Config {
                 transceiverMaxIoRF,
                 "Maximum RF/t sent and received by a Dimensional Transceiver per tick. Input and output limits are not cumulative")
                 .getInt(transceiverMaxIoRF);
+        transceiverInternalBuffer = config
+                .get(
+                        sectionPower.name,
+                        "transceiverInternalBuffer",
+                        transceiverInternalBuffer,
+                        "Maximum RF for the send/receive buffer. Need to be at least transceiverMaxIoRF.")
+                .getInt(transceiverInternalBuffer);
         transceiverBucketTransmissionCostRF = config
                 .get(
                         sectionEfficiency.name,

--- a/src/main/java/crazypants/enderio/machine/transceiver/TileTransceiver.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/TileTransceiver.java
@@ -54,7 +54,7 @@ public class TileTransceiver extends AbstractPoweredTaskEntity
     private final ICapacitor capacitor = new BasicCapacitor(
             0,
             Config.transceiverMaxIoRF * 2,
-            500000,
+            Config.transceiverInternalBuffer,
             Config.transceiverMaxIoRF);
     private boolean sendChannelsDirty = false;
     private boolean recieveChannelsDirty = false;


### PR DESCRIPTION
It's not possible to incrase the `transceiverMaxIoRF` over the hardcoded 500.000/2 RF for internal capacitor bank.
This PR changes this by making it configurable.