### PR TITLE
Implement item bar visibility config

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -1919,15 +1919,15 @@ public final class Config {
                 addFuelTooltipsToAllFluidContainers,
                 "If true, adds burn duration tooltips to furnace fuels").getBoolean(addFurnaceFuelTootip);
         renderChargeBar = config.get(
-            sectionPersonal.name,
-            "renderChargeBar",
-            renderChargeBar,
-            "If true, render the bar when an item has RF").getBoolean(renderChargeBar);
+                sectionPersonal.name,
+                "renderChargeBar",
+                renderChargeBar,
+                "If true, render the bar when an item has RF").getBoolean(renderChargeBar);
         renderDurabilityBar = config.get(
-            sectionPersonal.name,
-            "renderDurabilityBar",
-            renderDurabilityBar,
-            "If true, render the bar when an item is damaged").getBoolean(renderDurabilityBar);
+                sectionPersonal.name,
+                "renderDurabilityBar",
+                renderDurabilityBar,
+                "If true, render the bar when an item is damaged").getBoolean(renderDurabilityBar);
 
         farmContinuousEnergyUseRF = config.get(
                 sectionFarm.name,

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -321,6 +321,8 @@ public final class Config {
     public static boolean addFuelTooltipsToAllFluidContainers = true;
     public static boolean addFurnaceFuelTootip = true;
     public static boolean addDurabilityTootip = true;
+    public static boolean renderDurabilityBar = true;
+    public static boolean renderChargeBar = true;
 
     public static int farmContinuousEnergyUseRF = 40;
     public static int farmActionEnergyUseRF = 500;
@@ -1916,6 +1918,16 @@ public final class Config {
                 "addFurnaceFuelTootip",
                 addFuelTooltipsToAllFluidContainers,
                 "If true, adds burn duration tooltips to furnace fuels").getBoolean(addFurnaceFuelTootip);
+        renderChargeBar = config.get(
+            sectionPersonal.name,
+            "renderChargeBar",
+            renderChargeBar,
+            "If true, render the bar when an item has RF").getBoolean(renderChargeBar);
+        renderDurabilityBar = config.get(
+            sectionPersonal.name,
+            "renderDurabilityBar",
+            renderDurabilityBar,
+            "If true, render the bar when an item is damaged").getBoolean(renderDurabilityBar);
 
         farmContinuousEnergyUseRF = config.get(
                 sectionFarm.name,

--- a/src/main/java/crazypants/enderio/item/ItemMagnet.java
+++ b/src/main/java/crazypants/enderio/item/ItemMagnet.java
@@ -236,4 +236,9 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
         return true;
     }
+
+    @Override
+    public boolean showDurabilityBar(ItemStack stack) {
+        return Config.renderDurabilityBar && super.showDurabilityBar(stack);
+    }
 }

--- a/src/main/java/crazypants/enderio/item/darksteel/PoweredItemRenderer.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/PoweredItemRenderer.java
@@ -15,6 +15,7 @@ import com.enderio.core.client.render.RenderUtil;
 import com.enderio.core.common.vecmath.Vector4f;
 
 import cofh.api.energy.IEnergyContainerItem;
+import crazypants.enderio.config.Config;
 import crazypants.enderio.item.darksteel.upgrade.EnergyUpgrade;
 
 public class PoweredItemRenderer implements IItemRenderer {
@@ -44,26 +45,29 @@ public class PoweredItemRenderer implements IItemRenderer {
         ri.renderItemIntoGUI(mc.fontRenderer, mc.getTextureManager(), item, 0, 0, true);
         GL11.glDisable(GL11.GL_LIGHTING);
 
-        if (isJustCrafted(item)) {
+        if (isJustCrafted(item) || (!Config.renderChargeBar && !Config.renderDurabilityBar)) {
             return;
         }
 
         boolean hasEnergyUpgrade = EnergyUpgrade.loadFromItem(item) != null;
-        int y = hasEnergyUpgrade ? 12 : 13;
-        int bgH = hasEnergyUpgrade ? 4 : 2;
+        int y = (Config.renderDurabilityBar ^ Config.renderChargeBar) || !hasEnergyUpgrade ? 13 : 12;
+        int bgH = (Config.renderDurabilityBar ^ Config.renderChargeBar) || !hasEnergyUpgrade ? 2 : 4;
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         RenderUtil.renderQuad2D(2, y, 0, 13, bgH, ColorUtil.getRGB(Color.black));
 
-        double maxDam = item.getMaxDamage();
-        double dispDamage = item.getItemDamageForDisplay();
-        y = hasEnergyUpgrade ? 14 : 13;
-        renderBar(y, maxDam, dispDamage, Color.green, Color.red);
+        double maxDam, dispDamage;
+        if (Config.renderDurabilityBar) {
+            maxDam = item.getMaxDamage();
+            dispDamage = item.getItemDamageForDisplay();
+            y = Config.renderChargeBar && hasEnergyUpgrade ? 14 : 13;
+            renderBar(y, maxDam, dispDamage, Color.green, Color.red);
+        }
 
-        if (hasEnergyUpgrade) {
+        if (Config.renderChargeBar && hasEnergyUpgrade) {
             IEnergyContainerItem armor = (IEnergyContainerItem) item.getItem();
             maxDam = armor.getMaxEnergyStored(item);
             dispDamage = armor.getEnergyStored(item);
-            y = 12;
+            y = Config.renderDurabilityBar ? 12 : 13;
             Color color = new Color(0x2D, 0xCE, 0xFA); // electric blue
             renderBar2(y, maxDam, maxDam - dispDamage, color, color);
         }

--- a/src/main/java/crazypants/enderio/machine/capbank/BlockItemCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/BlockItemCapBank.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import cofh.api.energy.IEnergyContainerItem;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.EnderIOTab;
+import crazypants.enderio.config.Config;
 import crazypants.enderio.power.PowerHandlerUtil;
 
 public class BlockItemCapBank extends ItemBlock implements IEnergyContainerItem {
@@ -42,7 +43,7 @@ public class BlockItemCapBank extends ItemBlock implements IEnergyContainerItem 
 
     @Override
     public boolean showDurabilityBar(ItemStack itemStack) {
-        return !CapBankType.getTypeFromMeta(itemStack.getItemDamage()).isCreative();
+        return Config.renderDurabilityBar && !CapBankType.getTypeFromMeta(itemStack.getItemDamage()).isCreative();
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
@@ -177,4 +177,9 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
     public boolean isFull3D() {
         return true;
     }
+
+    @Override
+    public boolean showDurabilityBar(ItemStack stack) {
+        return Config.renderDurabilityBar && super.showDurabilityBar(stack);
+    }
 }


### PR DESCRIPTION
Same implementation/reason as https://github.com/GTNewHorizons/GT5-Unofficial/pull/2041

Added configs (personal section, both default to true)
![image](https://github.com/GTNewHorizons/EnderIO/assets/18713839/e66d2b05-5d3d-4402-ae82-eee7a4c9a5a6)


Default:
![image](https://github.com/GTNewHorizons/EnderIO/assets/18713839/6f40c56a-47d3-476c-8df1-7a3ad54f33e1)


No Durability Bar (caps, magnets, etc use minecraft `itemDamage` and will be handled in https://github.com/GTNewHorizons/DuraDisplay):
![image](https://github.com/GTNewHorizons/EnderIO/assets/18713839/876debe5-bbe5-4d17-89eb-dd402ad467bd)

No Charge Bar (notice the black background is also adjusted):
![image](https://github.com/GTNewHorizons/EnderIO/assets/18713839/9f0a4603-86f5-41f0-bc27-7c554e72d02b)

Both Off:
![image](https://github.com/GTNewHorizons/EnderIO/assets/18713839/222589e1-120f-496e-8429-5a015923cd6d)
