### PR TITLE
Set fluid conduit default connection mode to output only

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
@@ -153,7 +153,7 @@ public abstract class AbstractConduit implements IConduit {
     }
 
     protected ConnectionMode getDefaultConnectionMode() {
-        return ConnectionMode.INPUT;
+        return ConnectionMode.IN_OUT;
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/conduit/item/ItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/item/ItemConduit.java
@@ -601,6 +601,11 @@ public class ItemConduit extends AbstractConduit implements IItemConduit {
     }
 
     @Override
+    protected ConnectionMode getDefaultConnectionMode() {
+        return ConnectionMode.INPUT;
+    }
+
+    @Override
     public Class<? extends IConduit> getBaseConduitType() {
         return IItemConduit.class;
     }

--- a/src/main/java/crazypants/enderio/conduit/liquid/AbstractLiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/AbstractLiquidConduit.java
@@ -157,11 +157,11 @@ public abstract class AbstractLiquidConduit extends AbstractConduit implements I
         boolean res;
         if (mode == RedstoneControlMode.OFF) {
             // if checking for no signal, must be no signal from both
-            res = mode.isConditionMet(mode, signal)
+            res = RedstoneControlMode.isConditionMet(mode, signal)
                     && (col != DyeColor.RED || isConditionMetByExternalSignal(dir, mode, col));
         } else {
             // if checking for a signal, either is fine
-            res = mode.isConditionMet(mode, signal)
+            res = RedstoneControlMode.isConditionMet(mode, signal)
                     || (col == DyeColor.RED && isConditionMetByExternalSignal(dir, mode, col));
         }
         return res;
@@ -180,7 +180,12 @@ public abstract class AbstractLiquidConduit extends AbstractConduit implements I
             }
         }
 
-        return mode.isConditionMet(mode, externalSignal);
+        return RedstoneControlMode.isConditionMet(mode, externalSignal);
+    }
+
+    @Override
+    protected ConnectionMode getDefaultConnectionMode() {
+        return ConnectionMode.INPUT;
     }
 
     @Override


### PR DESCRIPTION
By changing the default connection mode in `AbstractConduit` in my other PR https://github.com/GTNewHorizons/EnderIO/pull/134, it affected all the conduits.
![image](https://github.com/GTNewHorizons/EnderIO/assets/57050655/5777fb6a-a022-4684-8e7a-a0b23cfa13ae)

This PR reverts the previous change, and changes the default only for fluid conduits

btw this is a great example of why we shouldn't squash all PR, because when you try to look at the changes made in https://github.com/GTNewHorizons/EnderIO/pull/134 from the git log, it now shows 40 files changed when in reality only 6 lines were changed, the rest of the stuff in spotless