### PR TITLE
Clientside world leak

### DIFF
--- a/src/main/java/crazypants/enderio/machine/obelisk/ObeliskSpecialRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/ObeliskSpecialRenderer.java
@@ -114,7 +114,7 @@ public class ObeliskSpecialRenderer<T extends TileEntity> extends TileEntitySpec
 
     protected void renderItemStack(T te, World world, double x, double y, double z, float tick) {
         if (ei == null) {
-            ei = new EntityItem(world, 0, 0, 0, getFloatingItem(te));
+            ei = new EntityItem(null, 0, 0, 0, getFloatingItem(te));
         }
 
         ei.setEntityItemStack(getFloatingItem(te));

--- a/src/main/java/crazypants/enderio/waila/WailaCompat.java
+++ b/src/main/java/crazypants/enderio/waila/WailaCompat.java
@@ -125,8 +125,6 @@ public class WailaCompat implements IWailaDataProvider {
 
     public static final WailaCompat INSTANCE = new WailaCompat();
 
-    private static IWailaDataAccessor _accessor = null;
-
     public static void load(IWailaRegistrar registrar) {
         registrar.registerStackProvider(INSTANCE, IFacade.class);
         registrar.registerStackProvider(INSTANCE, BlockDarkSteelAnvil.class);
@@ -189,8 +187,6 @@ public class WailaCompat implements IWailaDataProvider {
     @Override
     public List<String> getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
             IWailaConfigHandler config) {
-
-        _accessor = accessor;
 
         EntityPlayer player = accessor.getPlayer();
         MovingObjectPosition pos = accessor.getPosition();
@@ -267,7 +263,7 @@ public class WailaCompat implements IWailaDataProvider {
         }
 
         if (te instanceof IConduitBundle) {
-            getWailaBodyConduitBundle(itemStack, currenttip);
+            getWailaBodyConduitBundle(itemStack, currenttip, accessor);
 
         } else if (te instanceof IInternalPoweredTile && block == accessor.getBlock() && !(te instanceof TileCapBank)) {
             IInternalPoweredTile power = (IInternalPoweredTile) te;
@@ -297,13 +293,13 @@ public class WailaCompat implements IWailaDataProvider {
         return currenttip;
     }
 
-    private void getWailaBodyConduitBundle(ItemStack itemStack, List<String> currenttip) {
+    private void getWailaBodyConduitBundle(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor) {
         if (itemStack == null) {
             return;
         }
 
         if (itemStack.getItem() == EnderIO.itemPowerConduit || itemStack.getItem() == EnderIO.itemPowerConduitEndergy) {
-            NBTTagCompound nbtRoot = _accessor.getNBTData();
+            NBTTagCompound nbtRoot = accessor.getNBTData();
             if (nbtRoot.hasKey("storedEnergyRF")) {
                 int stored = nbtRoot.getInteger("storedEnergyRF");
                 int max = nbtRoot.getInteger("maxStoredRF");
@@ -320,7 +316,7 @@ public class WailaCompat implements IWailaDataProvider {
             }
 
         } else if (itemStack.getItem() == EnderIO.itemLiquidConduit) {
-            NBTTagCompound nbtRoot = _accessor.getNBTData();
+            NBTTagCompound nbtRoot = accessor.getNBTData();
             if (nbtRoot.hasKey("fluidLocked") && nbtRoot.hasKey("FluidName")) {
                 boolean fluidTypeLocked = nbtRoot.getBoolean("fluidLocked");
                 FluidStack fluid = FluidStack.loadFluidStackFromNBT(nbtRoot);
@@ -352,7 +348,7 @@ public class WailaCompat implements IWailaDataProvider {
             }
 
         } else if (itemStack.getItem() == EnderIO.itemMEConduit) {
-            NBTTagCompound nbtRoot = _accessor.getNBTData();
+            NBTTagCompound nbtRoot = accessor.getNBTData();
             if (nbtRoot.hasKey("isDense")) {
                 boolean isDenseUltra = nbtRoot.getBoolean("isDenseUltra");
                 boolean isDense = nbtRoot.getBoolean("isDense");
@@ -411,7 +407,4 @@ public class WailaCompat implements IWailaDataProvider {
         return tag;
     }
 
-    public static NBTTagCompound getNBTData() {
-        return _accessor.getNBTData();
-    }
 }


### PR DESCRIPTION
Fixes two instances that leak the world on the client.

![image](https://github.com/GTNewHorizons/EnderIO/assets/45769595/ef623eda-facb-4b54-81e6-853606220e68)

This one leaks the world by keeping an `EntityItem` instance alive that has a reference to the world [here](https://github.com/Minecraft-TA/EnderIO/blob/2470e81f0ef0e63405f494a165fd9aad3a13d85c/src/main/java/crazypants/enderio/machine/obelisk/ObeliskSpecialRenderer.java#L98). The fix just passes null to the `EntityItem` as its only used to render the item above the obelisks and it works fine without a world instance.

![image](https://github.com/GTNewHorizons/EnderIO/assets/45769595/d3cf2857-40bd-480f-84bc-828ceb7edeea)

The second leak is storing an unnecessary instance of `IWailaDataAccessor` that stores the current world. The fix here is just to delete the field as it has no real usages and pass it as a parameter.