### PR TITLE
Add unload event handling to ClientNetworkManager

### DIFF
--- a/src/main/java/crazypants/enderio/machine/capbank/network/ClientNetworkManager.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/network/ClientNetworkManager.java
@@ -4,12 +4,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WorldEvent;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import crazypants.enderio.machine.capbank.TileCapBank;
 
 public class ClientNetworkManager {
 
     private static final ClientNetworkManager instance = new ClientNetworkManager();
+
+    static {
+        MinecraftForge.EVENT_BUS.register(instance);
+    }
 
     public static ClientNetworkManager getInstance() {
         return instance;
@@ -52,5 +59,13 @@ public class ClientNetworkManager {
     public void addToNetwork(int id, TileCapBank tileCapBank) {
         CapBankClientNetwork network = getOrCreateNetwork(id);
         network.addMember(tileCapBank);
+    }
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        if (event.world.isRemote) {
+            networks.forEach((id, network) -> network.destroyNetwork());
+            networks.clear();
+        }
     }
 }


### PR DESCRIPTION
Added a new method `onWorldUnload` to `ClientNetworkManager` to destroy and clear any network instances when the world event `Unload` is triggered. The addition of this event handler was necessary to prevent the possibility of any network instances persisting on the client side beyond the World lifetime, thus potentially causing memory leaks.