### PR TITLE
Fix an edge case pertaining to freshly crafted tanks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1699290261
+//version: 1702141377
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -28,27 +28,12 @@ import java.util.concurrent.TimeUnit
 
 buildscript {
     repositories {
-        mavenCentral()
-
-        maven {
-            name 'forge'
-            url 'https://maven.minecraftforge.net'
-        }
         maven {
             // GTNH RetroFuturaGradle and ASM Fork
             name "GTNH Maven"
             url "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
             allowInsecureProtocol = true
         }
-        maven {
-            name 'sonatype'
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
-        maven {
-            name 'Scala CI dependencies'
-            url 'https://repo1.maven.org/maven2/'
-        }
-
         mavenLocal()
     }
 }
@@ -69,7 +54,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.24'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.26'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -302,7 +287,7 @@ if (apiPackage) {
 }
 
 if (accessTransformersFile) {
-    for (atFile in accessTransformersFile.split(",")) {
+    for (atFile in accessTransformersFile.split(" ")) {
         String targetFile = "src/main/resources/META-INF/" + atFile.trim()
         if (!getFile(targetFile).exists()) {
             throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
@@ -628,7 +613,7 @@ repositories {
         }
         maven {
             name = "ic2"
-            url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
+            url = getURL("https://maven2.ic2.player.to/", "https://maven.ic2.player.to/")
             content {
                 includeGroup "net.industrial-craft"
             }
@@ -687,6 +672,8 @@ configurations.all {
         substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
         substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
         substitute module('io.github.legacymoddingmc:unimixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Our previous unimixins upload was missing the dev classifier")
+
+        substitute module('org.scala-lang:scala-library:2.11.1') using module('org.scala-lang:scala-library:2.11.5') because('To allow mixing with Java 8 targets')
     }
 }
 
@@ -793,12 +780,12 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.5.1'
+    def lwjgl3ifyVersion = '1.5.7'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.17')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.35')
     }
 
     java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches") {transitive = false}
@@ -1310,7 +1297,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.2.1"
+def buildscriptGradleVersion = "8.5"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,19 +3,19 @@
 dependencies {
     api('com.github.GTNewHorizons:EnderCore:0.2.18:dev')
     implementation('com.github.GTNewHorizons:ForestryMC:4.7.0:dev')
-    implementation('com.github.GTNewHorizons:NotEnoughItems:2.4.12-GTNH:dev')
+    implementation('com.github.GTNewHorizons:NotEnoughItems:2.4.13-GTNH:dev')
     implementation("com.github.GTNewHorizons:GTNHLib:0.0.13:dev")
-    api('com.github.GTNewHorizons:BuildCraft:7.1.36:dev')
+    api('com.github.GTNewHorizons:BuildCraft:7.1.37:dev')
     api('curse.maven:cofh-lib-220333:2388748') // https://www.curseforge.com/minecraft/mc-mods/cofh-lib/files/2388748
     shadowImplementation('cglib:cglib-nodep:3.3.0')
 
-    compileOnly('com.github.GTNewHorizons:waila:1.6.3:api') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-282-GTNH:api') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Baubles:1.0.1.16:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.83:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Railcraft:9.15.1:api') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:waila:1.6.5:api') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-291-GTNH:api') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Baubles:1.0.3:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.106:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Railcraft:9.15.2:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:StorageDrawers:1.12.1-GTNH:api') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Chisel:2.12.2-GTNH:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Chisel:2.12.3-GTNH:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.9.19-GTNH:api') {transitive = false}
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150') // https://www.curseforge.com/minecraft/mc-mods/minefactory-reloaded/files/2366150
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')

--- a/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
@@ -489,11 +489,7 @@ public abstract class AbstractMachineEntity extends TileEntityEio
         if (stack == null || stack.stackTagCompound == null) {
             return;
         }
-        NBTTagCompound root = stack.stackTagCompound;
-        if (!root.hasKey("eio.abstractMachine")) {
-            return;
-        }
-        readCommon(root);
+        readCommon(stack.stackTagCompound);
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/tank/BlockItemTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/BlockItemTank.java
@@ -71,14 +71,12 @@ public class BlockItemTank extends ItemBlockWithMetadata implements IAdvancedToo
         EnderIO.blockTank.addDetailedEntries(itemstack, entityplayer, list, flag);
     }
 
-    private static final FluidTank dummy = new SmartTank(FluidRegistry.WATER, 16000);
-
     private FluidTank loadTank(ItemStack stack) {
         if (stack.hasTagCompound()) {
             FluidTank tank = TileTank.loadTank(stack.getTagCompound());
-            return tank != null ? tank : dummy;
+            return tank != null ? tank : new SmartTank(FluidRegistry.WATER, 16000);
         }
-        return dummy;
+        return new SmartTank(FluidRegistry.WATER, 16000);
     }
 
     private void saveTank(ItemStack stack, FluidTank tank) {


### PR DESCRIPTION
A demonstration of the bug is available on YouTube [here](https://youtu.be/IOl1y-1E8TY)

In essence, when attempting to fill a tank that has been freshly crafted and otherwise contains no NBT data the apparent creation of a new SuperTank object is instead using the same SuperTank object over and over and thereby filling the tank with more water than should be possible. It's likely that the `static final` dummy object was intended to be a constant but Java's final keyword does not prevent the associated object's fields from being updated.