### PR TITLE
Add Config to allow servers to re-enable support for client-side 'hacks' like Staff Of Traveling Keybind mod.

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -1199,12 +1199,6 @@ public final class Config {
                 sectionStaff.name,
                 travelStaffBlinkBlackList,
                 "Lists the blocks that cannot be teleported through in the form 'modID:blockName'");
-        validateTravelEventServerside = config.get(
-                sectionStaff.name,
-                "validateTravelEventServerside",
-                validateTravelEventServerside,
-                "If set to true: Server will validate if player actually can teleport. False will allow hacking, but also allows Staff of Traveling Keybind mod to work.")
-                .getBoolean(validateTravelEventServerside);
         travelAnchorZoomScale = config.getFloat(
                 "travelAnchorZoomScale",
                 sectionStaff.name,
@@ -1220,6 +1214,13 @@ public final class Config {
                         + "You can now teleport onto the roof. "
                         + "This config is experimental, so if you encounter any strange behavior, please report to GTNH developer.")
                 .getBoolean(travelStaffSearchOptimize);
+
+        validateTravelEventServerside = config.get(
+                sectionStaff.name,
+                "validateTravelEventServerside",
+                validateTravelEventServerside,
+                "If set to true: Server will validate if player actually can teleport. False will allow hacking, but also allows Staff of Traveling Keybind mod to work.")
+                .getBoolean(validateTravelEventServerside);
 
         teleportStaffMaxDistance = config
                 .get(

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -161,6 +161,7 @@ public final class Config {
     public static String[] travelStaffBlinkBlackList = new String[] { "minecraft:bedrock", "Thaumcraft:blockWarded" };
     public static float travelAnchorZoomScale = 0.2f;
     public static boolean travelStaffSearchOptimize = true;
+    public static boolean validateTravelEventServerside = true;
 
     /** The max distance for travelling to a Travel Anchor. */
     public static int teleportStaffMaxDistance = 2048;
@@ -1198,6 +1199,12 @@ public final class Config {
                 sectionStaff.name,
                 travelStaffBlinkBlackList,
                 "Lists the blocks that cannot be teleported through in the form 'modID:blockName'");
+        validateTravelEventServerside = config.get(
+                sectionStaff.name,
+                "validateTravelEventServerside",
+                validateTravelEventServerside,
+                "If set to true: Server will validate if player actually can teleport. False will allow hacking, but also allows Staff of Traveling Keybind mod to work.")
+                .getBoolean(validateTravelEventServerside);
         travelAnchorZoomScale = config.getFloat(
                 "travelAnchorZoomScale",
                 sectionStaff.name,

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -124,6 +124,11 @@ public class TravelController {
      */
     public String validatePacketTravelEvent(EntityPlayerMP toTp, int x, int y, int z, int powerUse,
             boolean conserveMotion, TravelSource source) {
+
+        // If config indicates to allow for 'hacking' the travel packet, then don't do any validation.
+        if(!Config.validateTravelEventServerside)
+            return null;
+        
         BlockCoord target = new BlockCoord(x, y, z);
         double dist = getDistanceSquared(toTp, target);
         // allow 15% overshoot to account for rounding

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -126,9 +126,8 @@ public class TravelController {
             boolean conserveMotion, TravelSource source) {
 
         // If config indicates to allow for 'hacking' the travel packet, then don't do any validation.
-        if(!Config.validateTravelEventServerside)
-            return null;
-        
+        if (!Config.validateTravelEventServerside) return null;
+
         BlockCoord target = new BlockCoord(x, y, z);
         double dist = getDistanceSquared(toTp, target);
         // allow 15% overshoot to account for rounding


### PR DESCRIPTION
Config obviously defaults to making it continue validating as is, but allows the Staff Of Traveling keybind mod to continue working without any substantial code changes and/or having to have a server-side component coded in that mod.

Did it this way simply because it was the easiest way all around to continue having a keybind to use the staff of traveling. 

EDIT: Oh yea, and for reference, the mod (functionality) I'm wanting to have back: https://github.com/TheUnderTaker11/Staff-Of-Traveling-Keybind/tree/1.7.10
Not having to have it in your hand is SUPER nice, can't live without it now.