### PR TITLE
Staff Of Traveling Keybind Feature

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -154,11 +154,13 @@ public final class Config {
     public static int travelStaffBlinkPauseTicks = 10;
 
     public static boolean travelStaffEnabled = true;
+    public static boolean travelStaffAllowInBaublesSlot = true;
     public static boolean travelStaffBlinkEnabled = true;
     public static boolean travelStaffBlinkThroughSolidBlocksEnabled = true;
     public static boolean travelStaffBlinkThroughClearBlocksEnabled = true;
     public static boolean travelStaffBlinkThroughUnbreakableBlocksEnabled = false;
     public static String[] travelStaffBlinkBlackList = new String[] { "minecraft:bedrock", "Thaumcraft:blockWarded" };
+    public static String travelStaffBaublesType = "AMULET";
     public static float travelAnchorZoomScale = 0.2f;
     public static boolean travelStaffSearchOptimize = true;
     public static boolean validateTravelEventServerside = true;
@@ -1166,6 +1168,13 @@ public final class Config {
                 "travelStaffEnabled",
                 travelAnchorEnabled,
                 "If set to false: the travel staff will not be craftable.").getBoolean(travelStaffEnabled);
+        travelStaffAllowInBaublesSlot = config
+                .get(
+                        sectionStaff.name,
+                        "travelStaffAllowInBaublesSlot",
+                        travelStaffAllowInBaublesSlot,
+                        "If true the travel staff can be put into Baubles slots (requires Baubles to be installed)")
+                .getBoolean(travelStaffAllowInBaublesSlot);
         travelStaffBlinkEnabled = config
                 .get(
                         sectionStaff.name,
@@ -1199,6 +1208,13 @@ public final class Config {
                 sectionStaff.name,
                 travelStaffBlinkBlackList,
                 "Lists the blocks that cannot be teleported through in the form 'modID:blockName'");
+        travelStaffBaublesType = config.get(
+                sectionStaff.name,
+                "travelStaffBaublesType",
+                travelStaffBaublesType,
+                "The BaublesType the Travel Staff should be, 'AMULET', 'RING' or 'BELT' (requires Baubles to be installed and travelStaffAllowInBaublesSlot to be on)")
+                .getString();
+
         travelAnchorZoomScale = config.getFloat(
                 "travelAnchorZoomScale",
                 sectionStaff.name,

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -155,6 +155,7 @@ public final class Config {
 
     public static boolean travelStaffEnabled = true;
     public static boolean travelStaffAllowInBaublesSlot = true;
+    public static boolean travelStaffKeybindEnabled = true;
     public static boolean travelStaffBlinkEnabled = true;
     public static boolean travelStaffBlinkThroughSolidBlocksEnabled = true;
     public static boolean travelStaffBlinkThroughClearBlocksEnabled = true;
@@ -1175,6 +1176,12 @@ public final class Config {
                         travelStaffAllowInBaublesSlot,
                         "If true the travel staff can be put into Baubles slots (requires Baubles to be installed)")
                 .getBoolean(travelStaffAllowInBaublesSlot);
+        travelStaffKeybindEnabled = config.get(
+                sectionStaff.name,
+                "travelStaffKeybindEnabled",
+                travelStaffKeybindEnabled,
+                "If set to false: the Travel Staff Blink keybind will not be useable. (keybind allows when staff is anywhere in inventory, might not be wanted)")
+                .getBoolean(travelStaffKeybindEnabled);
         travelStaffBlinkEnabled = config
                 .get(
                         sectionStaff.name,

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -161,7 +161,7 @@ public final class Config {
     public static boolean travelStaffBlinkThroughClearBlocksEnabled = true;
     public static boolean travelStaffBlinkThroughUnbreakableBlocksEnabled = false;
     public static String[] travelStaffBlinkBlackList = new String[] { "minecraft:bedrock", "Thaumcraft:blockWarded" };
-    public static String travelStaffBaublesType = "AMULET";
+    public static String travelStaffBaublesType = "UNIVERSAL";
     public static float travelAnchorZoomScale = 0.2f;
     public static boolean travelStaffSearchOptimize = true;
     public static boolean validateTravelEventServerside = true;
@@ -1219,7 +1219,7 @@ public final class Config {
                 sectionStaff.name,
                 "travelStaffBaublesType",
                 travelStaffBaublesType,
-                "The BaublesType the Travel Staff should be, 'AMULET', 'RING' or 'BELT' (requires Baubles to be installed and travelStaffAllowInBaublesSlot to be on)")
+                "The BaublesType the Travel Staff should be, 'AMULET', 'RING', 'BELT', or 'UNIVERSAL' (requires Baubles to be installed and travelStaffAllowInBaublesSlot to be on)")
                 .getString();
 
         travelAnchorZoomScale = config.getFloat(
@@ -2114,7 +2114,7 @@ public final class Config {
                 sectionMagnet.name,
                 "magnetAllowDeactivatedInBaublesSlot",
                 magnetAllowDeactivatedInBaublesSlot,
-                "If true the magnet can be put into the 'amulet' Baubles slot even if switched off (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)")
+                "If true the magnet can be put into a Baubles slot even if switched off (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)")
                 .getBoolean(magnetAllowDeactivatedInBaublesSlot);
 
         magnetAllowPowerExtraction = config.get(
@@ -2127,7 +2127,7 @@ public final class Config {
                 sectionMagnet.name,
                 "magnetBaublesType",
                 magnetBaublesType,
-                "The BaublesType the magnet should be, 'AMULET', 'RING' or 'BELT' (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)")
+                "The BaublesType the magnet should be, 'AMULET', 'RING', 'BELT', or UNIVERSAL (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)")
                 .getString();
 
         useCombustionGenModel = config

--- a/src/main/java/crazypants/enderio/config/PacketConfigSync.java
+++ b/src/main/java/crazypants/enderio/config/PacketConfigSync.java
@@ -27,6 +27,7 @@ public class PacketConfigSync implements IMessage, IMessageHandler<PacketConfigS
         buf.writeInt(Config.teleportStaffFailedBlinkDistance);
         buf.writeBoolean(Config.telepadLockCoords);
         buf.writeBoolean(Config.telepadLockDimension);
+        buf.writeBoolean(Config.travelStaffKeybindEnabled);
     }
 
     @Override
@@ -46,6 +47,7 @@ public class PacketConfigSync implements IMessage, IMessageHandler<PacketConfigS
         Config.teleportStaffFailedBlinkDistance = data.readInt();
         Config.telepadLockCoords = data.readBoolean();
         Config.telepadLockDimension = data.readBoolean();
+        Config.travelStaffKeybindEnabled = data.readBoolean();
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/item/ItemMagnet.java
+++ b/src/main/java/crazypants/enderio/item/ItemMagnet.java
@@ -206,6 +206,7 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     }
 
     @Override
+    @Method(modid = "Baubles|API")
     public void onWornTick(ItemStack itemstack, EntityLivingBase player) {
         if (player instanceof EntityPlayer && isActive(itemstack)
                 && hasPower(itemstack)
@@ -222,17 +223,21 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     }
 
     @Override
+    @Method(modid = "Baubles|API")
     public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
 
     @Override
+    @Method(modid = "Baubles|API")
     public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
 
     @Override
+    @Method(modid = "Baubles|API")
     public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
         return Config.magnetAllowInBaublesSlot && (Config.magnetAllowDeactivatedInBaublesSlot || isActive(itemstack));
     }
 
     @Override
+    @Method(modid = "Baubles|API")
     public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
         return true;
     }

--- a/src/main/java/crazypants/enderio/item/KeyTracker.java
+++ b/src/main/java/crazypants/enderio/item/KeyTracker.java
@@ -60,7 +60,7 @@ public class KeyTracker {
 
     private final KeyBinding staffOfTravelingTPKey;
 
-    private static long lastBlickTick = -1;
+    private static long lastBlinkTick = -1;
 
     public KeyTracker() {
         glideKey = new KeyBinding(
@@ -159,13 +159,13 @@ public class KeyTracker {
                     }
 
                     if (travelItem != null && travelItem.getItem() != null) {
-                        long ticksSinceBlink = EnderIO.proxy.getTickCount() - lastBlickTick;
+                        long ticksSinceBlink = EnderIO.proxy.getTickCount() - lastBlinkTick;
                         if (ticksSinceBlink < 0) {
-                            lastBlickTick = -1;
+                            lastBlinkTick = -1;
                         }
                         if (ticksSinceBlink >= Config.travelStaffBlinkPauseTicks) {
                             if (TravelController.instance.doBlink(travelItem, player)) {
-                                lastBlickTick = EnderIO.proxy.getTickCount();
+                                lastBlinkTick = EnderIO.proxy.getTickCount();
                             }
                         }
                     }

--- a/src/main/java/crazypants/enderio/item/KeyTracker.java
+++ b/src/main/java/crazypants/enderio/item/KeyTracker.java
@@ -8,6 +8,7 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentTranslation;
 
 import org.lwjgl.input.Keyboard;
 
@@ -148,25 +149,31 @@ public class KeyTracker {
 
     private void handleStaffOfTravelingTP() {
         if (staffOfTravelingTPKey.isPressed()) {
-            EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-            if (player != null) {
-                ItemStack travelItem = player.getHeldItem();
-                if (travelItem == null || travelItem.getItem() == null
-                        || !(travelItem.getItem() instanceof IItemOfTravel)) {
-                    travelItem = TravelController.instance.findTravelItemInInventoryOrBaubles(player);
-                }
-
-                if (travelItem != null && travelItem.getItem() != null) {
-                    long ticksSinceBlink = EnderIO.proxy.getTickCount() - lastBlickTick;
-                    if (ticksSinceBlink < 0) {
-                        lastBlickTick = -1;
+            if (Config.travelStaffKeybindEnabled) {
+                EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+                if (player != null) {
+                    ItemStack travelItem = player.getHeldItem();
+                    if (travelItem == null || travelItem.getItem() == null
+                            || !(travelItem.getItem() instanceof IItemOfTravel)) {
+                        travelItem = TravelController.instance.findTravelItemInInventoryOrBaubles(player);
                     }
-                    if (ticksSinceBlink >= Config.travelStaffBlinkPauseTicks) {
-                        if (TravelController.instance.doBlink(travelItem, player)) {
-                            lastBlickTick = EnderIO.proxy.getTickCount();
+
+                    if (travelItem != null && travelItem.getItem() != null) {
+                        long ticksSinceBlink = EnderIO.proxy.getTickCount() - lastBlickTick;
+                        if (ticksSinceBlink < 0) {
+                            lastBlickTick = -1;
+                        }
+                        if (ticksSinceBlink >= Config.travelStaffBlinkPauseTicks) {
+                            if (TravelController.instance.doBlink(travelItem, player)) {
+                                lastBlickTick = EnderIO.proxy.getTickCount();
+                            }
                         }
                     }
                 }
+            } else {
+                TravelController.showMessage(
+                        Minecraft.getMinecraft().thePlayer,
+                        new ChatComponentTranslation("enderio.travelStaffKeybind.isDisabled"));
             }
         }
     }

--- a/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
@@ -112,6 +112,10 @@ public class ItemTeleportStaff extends ItemTravelStaff {
 
     @Override
     public boolean isActive(EntityPlayer ep, ItemStack equipped) {
-        return isEquipped(ep);
+        if (ep != null && equipped != null) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
@@ -112,10 +112,6 @@ public class ItemTeleportStaff extends ItemTravelStaff {
 
     @Override
     public boolean isActive(EntityPlayer ep, ItemStack equipped) {
-        if (ep != null && equipped != null) {
-            return true;
-        } else {
-            return false;
-        }
+        return (ep != null && equipped != null);
     }
 }

--- a/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
@@ -202,25 +202,31 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
     }
 
     @Override
+    @Method(modid = "Baubles|API")
     public void onWornTick(ItemStack itemstack, EntityLivingBase player) {}
 
     @Override
+    @Method(modid = "Baubles|API")
     public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
 
     @Override
+    @Method(modid = "Baubles|API")
     public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
 
     @Override
+    @Method(modid = "Baubles|API")
     public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
         return Config.travelStaffAllowInBaublesSlot;
     }
 
     @Override
+    @Method(modid = "Baubles|API")
     public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
         return true;
     }
 
     @Override
+    @Method(modid = "Baubles|API")
     public boolean showDurabilityBar(ItemStack stack) {
         return Config.renderDurabilityBar && super.showDurabilityBar(stack);
     }

--- a/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -12,7 +13,11 @@ import net.minecraft.world.World;
 
 import com.enderio.core.api.client.gui.IResourceTooltipProvider;
 
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
 import cofh.api.energy.ItemEnergyContainer;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.common.Optional.Method;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -24,7 +29,8 @@ import crazypants.enderio.api.teleport.TravelSource;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.power.PowerDisplayUtil;
 
-public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTravel, IResourceTooltipProvider {
+@Optional.Interface(iface = "baubles.api.IBauble", modid = "Baubles|API")
+public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTravel, IResourceTooltipProvider, IBauble {
 
     public static boolean isEquipped(EntityPlayer ep) {
         if (ep == null || ep.getCurrentEquippedItem() == null) {
@@ -174,7 +180,11 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
 
     @Override
     public boolean isActive(EntityPlayer ep, ItemStack equipped) {
-        return isEquipped(ep);
+        if (ep != null && equipped != null) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -184,7 +194,39 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
     }
 
     @Override
+    @Method(modid = "Baubles|API")
+    public BaubleType getBaubleType(ItemStack itemstack) {
+        BaubleType t = null;
+        try {
+            t = BaubleType.valueOf(Config.travelStaffBaublesType);
+        } catch (Exception e) {
+            // NOP
+        }
+        return t != null ? t : BaubleType.AMULET;
+    }
+
+    @Override
+    public void onWornTick(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
+        return Config.travelStaffAllowInBaublesSlot;
+    }
+
+    @Override
+    public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
+        return true;
+    }
+
+    @Override
     public boolean showDurabilityBar(ItemStack stack) {
         return Config.renderDurabilityBar && super.showDurabilityBar(stack);
     }
+
 }

--- a/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
@@ -180,11 +180,7 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
 
     @Override
     public boolean isActive(EntityPlayer ep, ItemStack equipped) {
-        if (ep != null && equipped != null) {
-            return true;
-        } else {
-            return false;
-        }
+        return (ep != null && equipped != null);
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -158,9 +158,11 @@ public class TravelController {
                 return null;
             case STAFF:
             case STAFF_BLINK:
-                if (equippedItem == null || equippedItem.getItem() == null
-                        || !(equippedItem.getItem() instanceof IItemOfTravel)) {
-                    equippedItem = findTravelItemInInventoryOrBaubles(toTp);
+                if (Config.travelStaffKeybindEnabled) {
+                    if (equippedItem == null || equippedItem.getItem() == null
+                            || !(equippedItem.getItem() instanceof IItemOfTravel)) {
+                        equippedItem = findTravelItemInInventoryOrBaubles(toTp);
+                    }
                 }
                 if (equippedItem == null || !(equippedItem.getItem() instanceof IItemOfTravel)) return "not staff";
                 if (!((IItemOfTravel) equippedItem.getItem()).isActive(toTp, equippedItem)) return "staff not active";
@@ -1097,7 +1099,7 @@ public class TravelController {
         return null;
     }
 
-    private static void showMessage(EntityPlayer player, IChatComponent chatComponent) {
+    public static void showMessage(EntityPlayer player, IChatComponent chatComponent) {
         if (Loader.isModLoaded("gtnhlib")) {
             if (player instanceof EntityPlayerMP) {
                 chatComponent.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.WHITE));

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -16,6 +16,7 @@ import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
@@ -64,6 +65,7 @@ import crazypants.enderio.teleport.packet.PacketDrainStaff;
 import crazypants.enderio.teleport.packet.PacketLongDistanceTravelEvent;
 import crazypants.enderio.teleport.packet.PacketOpenAuthGui;
 import crazypants.enderio.teleport.packet.PacketTravelEvent;
+import crazypants.util.BaublesUtil;
 
 public class TravelController {
 
@@ -156,6 +158,10 @@ public class TravelController {
                 return null;
             case STAFF:
             case STAFF_BLINK:
+                if (equippedItem == null || equippedItem.getItem() == null
+                        || !(equippedItem.getItem() instanceof IItemOfTravel)) {
+                    equippedItem = findTravelItemInInventoryOrBaubles(toTp);
+                }
                 if (equippedItem == null || !(equippedItem.getItem() instanceof IItemOfTravel)) return "not staff";
                 if (!((IItemOfTravel) equippedItem.getItem()).isActive(toTp, equippedItem)) return "staff not active";
                 int energy = ((IItemOfTravel) equippedItem.getItem()).canExtractInternal(equippedItem, powerUse);
@@ -611,23 +617,97 @@ public class TravelController {
         return getTravelItemTravelSource(ep) != null;
     }
 
-    /** Returns null if no travel item is equipped. */
+    /** Returns null if no travel item is in inventory/baubles. */
     @Nullable
     public TravelSource getTravelItemTravelSource(EntityPlayer ep) {
-        if (ep == null || ep.getCurrentEquippedItem() == null) {
+        if (ep == null) {
             return null;
         }
+
         ItemStack equipped = ep.getCurrentEquippedItem();
-        if (equipped.getItem() instanceof ItemTeleportStaff) {
-            if (((ItemTeleportStaff) equipped.getItem()).isActive(ep, equipped)) {
-                return TravelSource.TELEPORT_STAFF;
-            }
-        } else if (equipped.getItem() instanceof IItemOfTravel) {
-            if (((IItemOfTravel) equipped.getItem()).isActive(ep, equipped)) {
-                return TravelSource.STAFF;
+        if (equipped == null || equipped.getItem() == null || !(equipped.getItem() instanceof IItemOfTravel)) {
+            equipped = findTravelItemInInventoryOrBaubles(ep);
+        }
+
+        if (equipped != null) {
+            if (equipped.getItem() instanceof ItemTeleportStaff) {
+                if (((ItemTeleportStaff) equipped.getItem()).isActive(ep, equipped)) {
+                    return TravelSource.TELEPORT_STAFF;
+                }
+            } else if (equipped.getItem() instanceof IItemOfTravel) {
+                if (((IItemOfTravel) equipped.getItem()).isActive(ep, equipped)) {
+                    return TravelSource.STAFF;
+                }
             }
         }
+
         return null;
+    }
+
+    /**
+     * Returns null if no Travel item found in inventory/baubles. <br>
+     * DO NOT CHANGE THIS CODE WITHOUT ALSO CHANGING
+     * TravelController.{@link #findTravelItemSlotInInventoryOrBaubles(EntityPlayer)}
+     */
+    @Nullable
+    public ItemStack findTravelItemInInventoryOrBaubles(EntityPlayer ep) {
+        ItemStack travelItem = null;
+        for (int i = 0; i < ep.inventory.getSizeInventory(); i++) {
+            ItemStack stack = ep.inventory.getStackInSlot(i);
+            if (stack != null && stack.getItem() != null && (stack.getItem() instanceof IItemOfTravel)) {
+                travelItem = stack;
+                break;
+            }
+        }
+
+        if (travelItem == null) {
+            IInventory baubles = BaublesUtil.instance().getBaubles(ep);
+            if (baubles != null) {
+                for (int i = 0; i < baubles.getSizeInventory(); i++) {
+                    ItemStack stack = baubles.getStackInSlot(i);
+                    if (stack != null && stack.getItem() != null && stack.getItem() instanceof IItemOfTravel) {
+                        travelItem = stack;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return travelItem;
+    }
+
+    /**
+     * Uses same code as {@link #findTravelItemInInventoryOrBaubles(EntityPlayer)}, but returns the slot of that
+     * item.<br>
+     * Baubles return value is unique/hacky, if <-1 return, then do the following to calculate the baubles slot:
+     * "Math.abs(returnval)-2" <br>
+     * Example: -3 return is Bauble slot 1, -2 return is Bauble slot 0
+     * 
+     * @return -1 if no travel item found. 0 or more if item found in inventory. -2 or less if item found in Baubles.
+     */
+    public int findTravelItemSlotInInventoryOrBaubles(EntityPlayer ep) {
+        int travelItemSlot = -1;
+        for (int i = 0; i < ep.inventory.getSizeInventory(); i++) {
+            ItemStack stack = ep.inventory.getStackInSlot(i);
+            if (stack != null && stack.getItem() != null && (stack.getItem() instanceof IItemOfTravel)) {
+                travelItemSlot = i;
+                break;
+            }
+        }
+
+        if (travelItemSlot == -1) {
+            IInventory baubles = BaublesUtil.instance().getBaubles(ep);
+            if (baubles != null) {
+                for (int i = 0; i < baubles.getSizeInventory(); i++) {
+                    ItemStack stack = baubles.getStackInSlot(i);
+                    if (stack != null && stack.getItem() != null && stack.getItem() instanceof IItemOfTravel) {
+                        travelItemSlot = -(i + 2);
+                        break;
+                    }
+                }
+            }
+        }
+        return travelItemSlot;
     }
 
     public boolean travelToSelectedTarget(EntityPlayer player, TravelSource source, boolean conserveMomentum) {
@@ -687,6 +767,10 @@ public class TravelController {
         }
         int requiredPower;
         ItemStack staff = player.getCurrentEquippedItem();
+        if (staff == null || staff.getItem() == null || !(staff.getItem() instanceof IItemOfTravel)) {
+            staff = findTravelItemInInventoryOrBaubles(player);
+        }
+
         requiredPower = getPower(player, source, coord, 0F);
         int canUsePower = getEnergyInTravelItem(staff);
         if (requiredPower > canUsePower) {

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -627,7 +627,7 @@ public class TravelController {
         }
 
         ItemStack equipped = ep.getCurrentEquippedItem();
-        if (equipped == null || equipped.getItem() == null || !(equipped.getItem() instanceof IItemOfTravel)) {
+        if (equipped == null || !(equipped.getItem() instanceof IItemOfTravel)) {
             equipped = findTravelItemInInventoryOrBaubles(ep);
         }
 
@@ -656,7 +656,7 @@ public class TravelController {
         ItemStack travelItem = null;
         for (int i = 0; i < ep.inventory.getSizeInventory(); i++) {
             ItemStack stack = ep.inventory.getStackInSlot(i);
-            if (stack != null && stack.getItem() != null && (stack.getItem() instanceof IItemOfTravel)) {
+            if (stack != null && stack.getItem() instanceof IItemOfTravel) {
                 travelItem = stack;
                 break;
             }
@@ -667,7 +667,7 @@ public class TravelController {
             if (baubles != null) {
                 for (int i = 0; i < baubles.getSizeInventory(); i++) {
                     ItemStack stack = baubles.getStackInSlot(i);
-                    if (stack != null && stack.getItem() != null && stack.getItem() instanceof IItemOfTravel) {
+                    if (stack != null && stack.getItem() instanceof IItemOfTravel) {
                         travelItem = stack;
                         break;
                     }
@@ -691,7 +691,7 @@ public class TravelController {
         int travelItemSlot = -1;
         for (int i = 0; i < ep.inventory.getSizeInventory(); i++) {
             ItemStack stack = ep.inventory.getStackInSlot(i);
-            if (stack != null && stack.getItem() != null && (stack.getItem() instanceof IItemOfTravel)) {
+            if (stack != null && (stack.getItem() instanceof IItemOfTravel)) {
                 travelItemSlot = i;
                 break;
             }
@@ -702,7 +702,7 @@ public class TravelController {
             if (baubles != null) {
                 for (int i = 0; i < baubles.getSizeInventory(); i++) {
                     ItemStack stack = baubles.getStackInSlot(i);
-                    if (stack != null && stack.getItem() != null && stack.getItem() instanceof IItemOfTravel) {
+                    if (stack != null && stack.getItem() instanceof IItemOfTravel) {
                         travelItemSlot = -(i + 2);
                         break;
                     }
@@ -769,7 +769,7 @@ public class TravelController {
         }
         int requiredPower;
         ItemStack staff = player.getCurrentEquippedItem();
-        if (staff == null || staff.getItem() == null || !(staff.getItem() instanceof IItemOfTravel)) {
+        if (staff == null || !(staff.getItem() instanceof IItemOfTravel)) {
             staff = findTravelItemInInventoryOrBaubles(player);
         }
 

--- a/src/main/resources/assets/enderio/lang/en_US.lang
+++ b/src/main/resources/assets/enderio/lang/en_US.lang
@@ -1391,6 +1391,7 @@ enderio.keybind.jump=Jump
 enderio.keybind.stepassist=Step Assist
 enderio.keybind.yetawrenchmode=Yeta Wrench Mode
 enderio.keybind.magnet=Toggle Electromagnet
+enderio.keybind.staffoftravelingtp=Travel Staff Blink
 enderio.nei.alloysmelter=Alloy Smelter
 enderio.nei.enchanter=Enchanter
 enderio.nei.sagmill=SAG Mill

--- a/src/main/resources/assets/enderio/lang/en_US.lang
+++ b/src/main/resources/assets/enderio/lang/en_US.lang
@@ -731,6 +731,7 @@ item.itemTravelStaff.tooltip.detailed.line3=activated by R-Click
 item.itemTravelStaff.tooltip.detailed.line4=Shift-R-Click will teleport the
 item.itemTravelStaff.tooltip.detailed.line5=player a short distance
 enderio.itemTravelStaff.notEnoughPower=Not enough power
+enderio.travelStaffKeybind.isDisabled=Travel Staff Blink Keybind Disabled!
 
 item.itemTeleportStaff.name=Staff of Teleportation
 item.itemTeleportStaff.tooltip.detailed.line1=R-Click to teleport wherever you are looking


### PR DESCRIPTION
Two main things
1. Added a keybind for Staff of Traveling blink ability
2. Due to the new keybind, also added Baubles support for Staff of Traveling.

By extension, both features 1 and 2 also apply to the Staff of Teleportation.

Further notes:
I have modified the "boolean isActive(EntityPlayer ep, ItemStack equipped)" on ItemTravelStaff and ItemTeleportStaff to just be true as long as the 'equipped' stack passed in isn't null. This isActive seems to me to lean more towards supporting enable/disabling items. It made no sense to me to have all this logic around if the player is holding the travel item, just to ask again, by passing in _the exact same item it pulled from player.getHeldItem()_. If I misunderstood something in reading the code let me know, otherwise I don't think my change to the isActive method will have any detriment.

Testing:
Tested with/without holding the staff
Tested with/without holding other items.
Tested in hotbar/other inventory.
Tested in Baubles slots.
Tested that existing staff functionality continues to work as expected (Shift blink and anchor teleport)
Before Teleport
![prbeforetppic](https://github.com/GTNewHorizons/EnderIO/assets/16872377/2d5ce7b8-243a-460e-862c-ab6d0f21d6ca)

After Teleport
![praftertppic](https://github.com/GTNewHorizons/EnderIO/assets/16872377/469a0e4e-0911-4218-99e2-b918abfbe30a)

Before TP in Baubles slot
![prbaublebeforetp](https://github.com/GTNewHorizons/EnderIO/assets/16872377/de5a5bb9-2c90-4c41-9e46-6ddb8ea6dad3)

After TP in Baubles slot
![prbaubleaftertp](https://github.com/GTNewHorizons/EnderIO/assets/16872377/7e77dbff-bd4a-454f-8460-087d98cef040)


Side unrelated note, I know this kind of makes my previous PR useless, I had done the previous one because I didn't think I would get the motivation to implement it proper this quickly but here we are lol.