### PR TITLE
Revert "Staff Of Traveling Keybind Feature (#144)"

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -154,14 +154,11 @@ public final class Config {
     public static int travelStaffBlinkPauseTicks = 10;
 
     public static boolean travelStaffEnabled = true;
-    public static boolean travelStaffAllowInBaublesSlot = true;
-    public static boolean travelStaffKeybindEnabled = true;
     public static boolean travelStaffBlinkEnabled = true;
     public static boolean travelStaffBlinkThroughSolidBlocksEnabled = true;
     public static boolean travelStaffBlinkThroughClearBlocksEnabled = true;
     public static boolean travelStaffBlinkThroughUnbreakableBlocksEnabled = false;
     public static String[] travelStaffBlinkBlackList = new String[] { "minecraft:bedrock", "Thaumcraft:blockWarded" };
-    public static String travelStaffBaublesType = "UNIVERSAL";
     public static float travelAnchorZoomScale = 0.2f;
     public static boolean travelStaffSearchOptimize = true;
     public static boolean validateTravelEventServerside = true;
@@ -1169,19 +1166,6 @@ public final class Config {
                 "travelStaffEnabled",
                 travelAnchorEnabled,
                 "If set to false: the travel staff will not be craftable.").getBoolean(travelStaffEnabled);
-        travelStaffAllowInBaublesSlot = config
-                .get(
-                        sectionStaff.name,
-                        "travelStaffAllowInBaublesSlot",
-                        travelStaffAllowInBaublesSlot,
-                        "If true the travel staff can be put into Baubles slots (requires Baubles to be installed)")
-                .getBoolean(travelStaffAllowInBaublesSlot);
-        travelStaffKeybindEnabled = config.get(
-                sectionStaff.name,
-                "travelStaffKeybindEnabled",
-                travelStaffKeybindEnabled,
-                "If set to false: the Travel Staff Blink keybind will not be useable. (keybind allows when staff is anywhere in inventory, might not be wanted)")
-                .getBoolean(travelStaffKeybindEnabled);
         travelStaffBlinkEnabled = config
                 .get(
                         sectionStaff.name,
@@ -1215,13 +1199,6 @@ public final class Config {
                 sectionStaff.name,
                 travelStaffBlinkBlackList,
                 "Lists the blocks that cannot be teleported through in the form 'modID:blockName'");
-        travelStaffBaublesType = config.get(
-                sectionStaff.name,
-                "travelStaffBaublesType",
-                travelStaffBaublesType,
-                "The BaublesType the Travel Staff should be, 'AMULET', 'RING', 'BELT', or 'UNIVERSAL' (requires Baubles to be installed and travelStaffAllowInBaublesSlot to be on)")
-                .getString();
-
         travelAnchorZoomScale = config.getFloat(
                 "travelAnchorZoomScale",
                 sectionStaff.name,
@@ -2114,7 +2091,7 @@ public final class Config {
                 sectionMagnet.name,
                 "magnetAllowDeactivatedInBaublesSlot",
                 magnetAllowDeactivatedInBaublesSlot,
-                "If true the magnet can be put into a Baubles slot even if switched off (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)")
+                "If true the magnet can be put into the 'amulet' Baubles slot even if switched off (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)")
                 .getBoolean(magnetAllowDeactivatedInBaublesSlot);
 
         magnetAllowPowerExtraction = config.get(
@@ -2127,7 +2104,7 @@ public final class Config {
                 sectionMagnet.name,
                 "magnetBaublesType",
                 magnetBaublesType,
-                "The BaublesType the magnet should be, 'AMULET', 'RING', 'BELT', or UNIVERSAL (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)")
+                "The BaublesType the magnet should be, 'AMULET', 'RING' or 'BELT' (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)")
                 .getString();
 
         useCombustionGenModel = config

--- a/src/main/java/crazypants/enderio/config/PacketConfigSync.java
+++ b/src/main/java/crazypants/enderio/config/PacketConfigSync.java
@@ -27,7 +27,6 @@ public class PacketConfigSync implements IMessage, IMessageHandler<PacketConfigS
         buf.writeInt(Config.teleportStaffFailedBlinkDistance);
         buf.writeBoolean(Config.telepadLockCoords);
         buf.writeBoolean(Config.telepadLockDimension);
-        buf.writeBoolean(Config.travelStaffKeybindEnabled);
     }
 
     @Override
@@ -47,7 +46,6 @@ public class PacketConfigSync implements IMessage, IMessageHandler<PacketConfigS
         Config.teleportStaffFailedBlinkDistance = data.readInt();
         Config.telepadLockCoords = data.readBoolean();
         Config.telepadLockDimension = data.readBoolean();
-        Config.travelStaffKeybindEnabled = data.readBoolean();
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/item/ItemMagnet.java
+++ b/src/main/java/crazypants/enderio/item/ItemMagnet.java
@@ -206,7 +206,6 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     }
 
     @Override
-    @Method(modid = "Baubles|API")
     public void onWornTick(ItemStack itemstack, EntityLivingBase player) {
         if (player instanceof EntityPlayer && isActive(itemstack)
                 && hasPower(itemstack)
@@ -223,21 +222,17 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     }
 
     @Override
-    @Method(modid = "Baubles|API")
     public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
 
     @Override
-    @Method(modid = "Baubles|API")
     public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
 
     @Override
-    @Method(modid = "Baubles|API")
     public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
         return Config.magnetAllowInBaublesSlot && (Config.magnetAllowDeactivatedInBaublesSlot || isActive(itemstack));
     }
 
     @Override
-    @Method(modid = "Baubles|API")
     public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
         return true;
     }

--- a/src/main/java/crazypants/enderio/item/KeyTracker.java
+++ b/src/main/java/crazypants/enderio/item/KeyTracker.java
@@ -8,7 +8,6 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ChatComponentTranslation;
 
 import org.lwjgl.input.Keyboard;
 
@@ -18,7 +17,6 @@ import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
 import crazypants.enderio.EnderIO;
-import crazypants.enderio.api.teleport.IItemOfTravel;
 import crazypants.enderio.api.tool.IConduitControl;
 import crazypants.enderio.conduit.ConduitDisplayMode;
 import crazypants.enderio.config.Config;
@@ -32,7 +30,6 @@ import crazypants.enderio.item.darksteel.upgrade.JumpUpgrade;
 import crazypants.enderio.item.darksteel.upgrade.SoundDetectorUpgrade;
 import crazypants.enderio.item.darksteel.upgrade.SpeedUpgrade;
 import crazypants.enderio.network.PacketHandler;
-import crazypants.enderio.teleport.TravelController;
 import crazypants.enderio.thaumcraft.GogglesOfRevealingUpgrade;
 import crazypants.util.BaublesUtil;
 
@@ -57,10 +54,6 @@ public class KeyTracker {
     private final KeyBinding yetaWrenchMode;
 
     private final KeyBinding magnetKey;
-
-    private final KeyBinding staffOfTravelingTPKey;
-
-    private static long lastBlinkTick = -1;
 
     public KeyTracker() {
         glideKey = new KeyBinding(
@@ -113,12 +106,6 @@ public class KeyTracker {
                 Keyboard.KEY_NONE,
                 EnderIO.lang.localize("category.tools"));
         ClientRegistry.registerKeyBinding(magnetKey);
-
-        staffOfTravelingTPKey = new KeyBinding(
-                EnderIO.lang.localize("keybind.staffoftravelingtp"),
-                Keyboard.KEY_NONE,
-                EnderIO.lang.localize("category.tools"));
-        ClientRegistry.registerKeyBinding(staffOfTravelingTPKey);
     }
 
     @SubscribeEvent
@@ -132,7 +119,6 @@ public class KeyTracker {
         handleSpeed();
         handleJump();
         handleMagnet();
-        handleStaffOfTravelingTP();
     }
 
     private void sendEnabledChatMessage(String messageBase, boolean isActive) {
@@ -145,37 +131,6 @@ public class KeyTracker {
         sendEnabledChatMessage(messageBase, isActive);
         DarkSteelController.instance.setActive(Minecraft.getMinecraft().thePlayer, type, isActive);
         PacketHandler.INSTANCE.sendToServer(new PacketUpgradeState(type, isActive));
-    }
-
-    private void handleStaffOfTravelingTP() {
-        if (staffOfTravelingTPKey.isPressed()) {
-            if (Config.travelStaffKeybindEnabled) {
-                EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-                if (player != null) {
-                    ItemStack travelItem = player.getHeldItem();
-                    if (travelItem == null || travelItem.getItem() == null
-                            || !(travelItem.getItem() instanceof IItemOfTravel)) {
-                        travelItem = TravelController.instance.findTravelItemInInventoryOrBaubles(player);
-                    }
-
-                    if (travelItem != null && travelItem.getItem() != null) {
-                        long ticksSinceBlink = EnderIO.proxy.getTickCount() - lastBlinkTick;
-                        if (ticksSinceBlink < 0) {
-                            lastBlinkTick = -1;
-                        }
-                        if (ticksSinceBlink >= Config.travelStaffBlinkPauseTicks) {
-                            if (TravelController.instance.doBlink(travelItem, player)) {
-                                lastBlinkTick = EnderIO.proxy.getTickCount();
-                            }
-                        }
-                    }
-                }
-            } else {
-                TravelController.showMessage(
-                        Minecraft.getMinecraft().thePlayer,
-                        new ChatComponentTranslation("enderio.travelStaffKeybind.isDisabled"));
-            }
-        }
     }
 
     private void handleMagnet() {

--- a/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
@@ -112,6 +112,6 @@ public class ItemTeleportStaff extends ItemTravelStaff {
 
     @Override
     public boolean isActive(EntityPlayer ep, ItemStack equipped) {
-        return (ep != null && equipped != null);
+        return isEquipped(ep);
     }
 }

--- a/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -13,11 +12,7 @@ import net.minecraft.world.World;
 
 import com.enderio.core.api.client.gui.IResourceTooltipProvider;
 
-import baubles.api.BaubleType;
-import baubles.api.IBauble;
 import cofh.api.energy.ItemEnergyContainer;
-import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.common.Optional.Method;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -29,8 +24,7 @@ import crazypants.enderio.api.teleport.TravelSource;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.power.PowerDisplayUtil;
 
-@Optional.Interface(iface = "baubles.api.IBauble", modid = "Baubles|API")
-public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTravel, IResourceTooltipProvider, IBauble {
+public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTravel, IResourceTooltipProvider {
 
     public static boolean isEquipped(EntityPlayer ep) {
         if (ep == null || ep.getCurrentEquippedItem() == null) {
@@ -180,7 +174,7 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
 
     @Override
     public boolean isActive(EntityPlayer ep, ItemStack equipped) {
-        return (ep != null && equipped != null);
+        return isEquipped(ep);
     }
 
     @Override
@@ -190,45 +184,7 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
     }
 
     @Override
-    @Method(modid = "Baubles|API")
-    public BaubleType getBaubleType(ItemStack itemstack) {
-        BaubleType t = null;
-        try {
-            t = BaubleType.valueOf(Config.travelStaffBaublesType);
-        } catch (Exception e) {
-            // NOP
-        }
-        return t != null ? t : BaubleType.AMULET;
-    }
-
-    @Override
-    @Method(modid = "Baubles|API")
-    public void onWornTick(ItemStack itemstack, EntityLivingBase player) {}
-
-    @Override
-    @Method(modid = "Baubles|API")
-    public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
-
-    @Override
-    @Method(modid = "Baubles|API")
-    public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
-
-    @Override
-    @Method(modid = "Baubles|API")
-    public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
-        return Config.travelStaffAllowInBaublesSlot;
-    }
-
-    @Override
-    @Method(modid = "Baubles|API")
-    public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
-        return true;
-    }
-
-    @Override
-    @Method(modid = "Baubles|API")
     public boolean showDurabilityBar(ItemStack stack) {
         return Config.renderDurabilityBar && super.showDurabilityBar(stack);
     }
-
 }

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -16,7 +16,6 @@ import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
@@ -65,7 +64,6 @@ import crazypants.enderio.teleport.packet.PacketDrainStaff;
 import crazypants.enderio.teleport.packet.PacketLongDistanceTravelEvent;
 import crazypants.enderio.teleport.packet.PacketOpenAuthGui;
 import crazypants.enderio.teleport.packet.PacketTravelEvent;
-import crazypants.util.BaublesUtil;
 
 public class TravelController {
 
@@ -158,12 +156,6 @@ public class TravelController {
                 return null;
             case STAFF:
             case STAFF_BLINK:
-                if (Config.travelStaffKeybindEnabled) {
-                    if (equippedItem == null || equippedItem.getItem() == null
-                            || !(equippedItem.getItem() instanceof IItemOfTravel)) {
-                        equippedItem = findTravelItemInInventoryOrBaubles(toTp);
-                    }
-                }
                 if (equippedItem == null || !(equippedItem.getItem() instanceof IItemOfTravel)) return "not staff";
                 if (!((IItemOfTravel) equippedItem.getItem()).isActive(toTp, equippedItem)) return "staff not active";
                 int energy = ((IItemOfTravel) equippedItem.getItem()).canExtractInternal(equippedItem, powerUse);
@@ -619,97 +611,23 @@ public class TravelController {
         return getTravelItemTravelSource(ep) != null;
     }
 
-    /** Returns null if no travel item is in inventory/baubles. */
+    /** Returns null if no travel item is equipped. */
     @Nullable
     public TravelSource getTravelItemTravelSource(EntityPlayer ep) {
-        if (ep == null) {
+        if (ep == null || ep.getCurrentEquippedItem() == null) {
             return null;
         }
-
         ItemStack equipped = ep.getCurrentEquippedItem();
-        if (equipped == null || !(equipped.getItem() instanceof IItemOfTravel)) {
-            equipped = findTravelItemInInventoryOrBaubles(ep);
-        }
-
-        if (equipped != null) {
-            if (equipped.getItem() instanceof ItemTeleportStaff) {
-                if (((ItemTeleportStaff) equipped.getItem()).isActive(ep, equipped)) {
-                    return TravelSource.TELEPORT_STAFF;
-                }
-            } else if (equipped.getItem() instanceof IItemOfTravel) {
-                if (((IItemOfTravel) equipped.getItem()).isActive(ep, equipped)) {
-                    return TravelSource.STAFF;
-                }
+        if (equipped.getItem() instanceof ItemTeleportStaff) {
+            if (((ItemTeleportStaff) equipped.getItem()).isActive(ep, equipped)) {
+                return TravelSource.TELEPORT_STAFF;
+            }
+        } else if (equipped.getItem() instanceof IItemOfTravel) {
+            if (((IItemOfTravel) equipped.getItem()).isActive(ep, equipped)) {
+                return TravelSource.STAFF;
             }
         }
-
         return null;
-    }
-
-    /**
-     * Returns null if no Travel item found in inventory/baubles. <br>
-     * DO NOT CHANGE THIS CODE WITHOUT ALSO CHANGING
-     * TravelController.{@link #findTravelItemSlotInInventoryOrBaubles(EntityPlayer)}
-     */
-    @Nullable
-    public ItemStack findTravelItemInInventoryOrBaubles(EntityPlayer ep) {
-        ItemStack travelItem = null;
-        for (int i = 0; i < ep.inventory.getSizeInventory(); i++) {
-            ItemStack stack = ep.inventory.getStackInSlot(i);
-            if (stack != null && stack.getItem() instanceof IItemOfTravel) {
-                travelItem = stack;
-                break;
-            }
-        }
-
-        if (travelItem == null) {
-            IInventory baubles = BaublesUtil.instance().getBaubles(ep);
-            if (baubles != null) {
-                for (int i = 0; i < baubles.getSizeInventory(); i++) {
-                    ItemStack stack = baubles.getStackInSlot(i);
-                    if (stack != null && stack.getItem() instanceof IItemOfTravel) {
-                        travelItem = stack;
-                        break;
-                    }
-                }
-            }
-        }
-
-        return travelItem;
-    }
-
-    /**
-     * Uses same code as {@link #findTravelItemInInventoryOrBaubles(EntityPlayer)}, but returns the slot of that
-     * item.<br>
-     * Baubles return value is unique/hacky, if <-1 return, then do the following to calculate the baubles slot:
-     * "Math.abs(returnval)-2" <br>
-     * Example: -3 return is Bauble slot 1, -2 return is Bauble slot 0
-     * 
-     * @return -1 if no travel item found. 0 or more if item found in inventory. -2 or less if item found in Baubles.
-     */
-    public int findTravelItemSlotInInventoryOrBaubles(EntityPlayer ep) {
-        int travelItemSlot = -1;
-        for (int i = 0; i < ep.inventory.getSizeInventory(); i++) {
-            ItemStack stack = ep.inventory.getStackInSlot(i);
-            if (stack != null && (stack.getItem() instanceof IItemOfTravel)) {
-                travelItemSlot = i;
-                break;
-            }
-        }
-
-        if (travelItemSlot == -1) {
-            IInventory baubles = BaublesUtil.instance().getBaubles(ep);
-            if (baubles != null) {
-                for (int i = 0; i < baubles.getSizeInventory(); i++) {
-                    ItemStack stack = baubles.getStackInSlot(i);
-                    if (stack != null && stack.getItem() instanceof IItemOfTravel) {
-                        travelItemSlot = -(i + 2);
-                        break;
-                    }
-                }
-            }
-        }
-        return travelItemSlot;
     }
 
     public boolean travelToSelectedTarget(EntityPlayer player, TravelSource source, boolean conserveMomentum) {
@@ -769,10 +687,6 @@ public class TravelController {
         }
         int requiredPower;
         ItemStack staff = player.getCurrentEquippedItem();
-        if (staff == null || !(staff.getItem() instanceof IItemOfTravel)) {
-            staff = findTravelItemInInventoryOrBaubles(player);
-        }
-
         requiredPower = getPower(player, source, coord, 0F);
         int canUsePower = getEnergyInTravelItem(staff);
         if (requiredPower > canUsePower) {
@@ -1099,7 +1013,7 @@ public class TravelController {
         return null;
     }
 
-    public static void showMessage(EntityPlayer player, IChatComponent chatComponent) {
+    private static void showMessage(EntityPlayer player, IChatComponent chatComponent) {
         if (Loader.isModLoaded("gtnhlib")) {
             if (player instanceof EntityPlayerMP) {
                 chatComponent.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.WHITE));

--- a/src/main/java/crazypants/enderio/teleport/packet/PacketTravelEvent.java
+++ b/src/main/java/crazypants/enderio/teleport/packet/PacketTravelEvent.java
@@ -3,7 +3,6 @@ package crazypants.enderio.teleport.packet;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.S12PacketEntityVelocity;
 import net.minecraftforge.common.MinecraftForge;
@@ -19,7 +18,6 @@ import crazypants.enderio.api.teleport.IItemOfTravel;
 import crazypants.enderio.api.teleport.TeleportEntityEvent;
 import crazypants.enderio.api.teleport.TravelSource;
 import crazypants.enderio.teleport.TravelController;
-import crazypants.util.BaublesUtil;
 import io.netty.buffer.ByteBuf;
 
 public class PacketTravelEvent implements IMessage, IMessageHandler<PacketTravelEvent, IMessage> {
@@ -130,35 +128,18 @@ public class PacketTravelEvent implements IMessage, IMessageHandler<PacketTravel
             if (conserveMotion) {
                 Vector3d velocityVex = Util.getLookVecEio(player);
                 S12PacketEntityVelocity p = new S12PacketEntityVelocity(
-                        player.getEntityId(),
+                        toTp.getEntityId(),
                         velocityVex.x,
                         velocityVex.y,
                         velocityVex.z);
                 ((EntityPlayerMP) player).playerNetServerHandler.sendPacket(p);
             }
 
-            ItemStack travelItem = player.getCurrentEquippedItem();
-            int itemSlot = -1;
-            if (travelItem == null || travelItem.getItem() == null
-                    || !(travelItem.getItem() instanceof IItemOfTravel)) {
-                travelItem = TravelController.instance.findTravelItemInInventoryOrBaubles(player);
-                itemSlot = TravelController.instance.findTravelItemSlotInInventoryOrBaubles(player);
-            }
-            if (powerUse > 0 && travelItem != null && travelItem.getItem() instanceof IItemOfTravel) {
-                ItemStack item = travelItem.copy();
+            if (powerUse > 0 && player.getCurrentEquippedItem() != null
+                    && player.getCurrentEquippedItem().getItem() instanceof IItemOfTravel) {
+                ItemStack item = player.getCurrentEquippedItem().copy();
                 ((IItemOfTravel) item.getItem()).extractInternal(item, powerUse);
-                if (itemSlot == -1) {
-                    // Is held in players hand.
-                    player.setCurrentItemOrArmor(0, item);
-                } else if (itemSlot > -1) {
-                    // Greater than -1 is an inventory slot.
-                    player.inventory.setInventorySlotContents(itemSlot, item);
-                } else if (itemSlot < -1) {
-                    // Less than -1 is a bauble slot. Special calculation needed to determine ACTUAL Baubles slot
-                    int baubleSlot = Math.abs(itemSlot) - 2;
-                    IInventory baubles = BaublesUtil.instance().getBaubles(player);
-                    baubles.setInventorySlotContents(baubleSlot, item);
-                }
+                toTp.setCurrentItemOrArmor(0, item);
             }
         }
 

--- a/src/main/resources/assets/enderio/lang/en_US.lang
+++ b/src/main/resources/assets/enderio/lang/en_US.lang
@@ -731,7 +731,6 @@ item.itemTravelStaff.tooltip.detailed.line3=activated by R-Click
 item.itemTravelStaff.tooltip.detailed.line4=Shift-R-Click will teleport the
 item.itemTravelStaff.tooltip.detailed.line5=player a short distance
 enderio.itemTravelStaff.notEnoughPower=Not enough power
-enderio.travelStaffKeybind.isDisabled=Travel Staff Blink Keybind Disabled!
 
 item.itemTeleportStaff.name=Staff of Teleportation
 item.itemTeleportStaff.tooltip.detailed.line1=R-Click to teleport wherever you are looking
@@ -1392,7 +1391,6 @@ enderio.keybind.jump=Jump
 enderio.keybind.stepassist=Step Assist
 enderio.keybind.yetawrenchmode=Yeta Wrench Mode
 enderio.keybind.magnet=Toggle Electromagnet
-enderio.keybind.staffoftravelingtp=Travel Staff Blink
 enderio.nei.alloysmelter=Alloy Smelter
 enderio.nei.enchanter=Enchanter
 enderio.nei.sagmill=SAG Mill


### PR DESCRIPTION
This reverts commit 3639ade571b519e3e4297bfb0fe8074f045b71ac.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15406

Until a better implementation is created, lets go ahead and revert this feature.  

Plus scanning your inventory/baubles every tick is not the best way to handle it.