### PR TITLE
Fix Anchor always rendering bug

### DIFF
--- a/src/main/java/crazypants/enderio/api/teleport/TravelSource.java
+++ b/src/main/java/crazypants/enderio/api/teleport/TravelSource.java
@@ -81,7 +81,7 @@ public enum TravelSource {
             return 0;
         }
 
-        TravelSource source = TravelController.instance.getTravelItemTravelSource(player);
+        TravelSource source = TravelController.instance.getTravelItemTravelSource(player, false);
         if (source == null) {
             return TravelSource.BLOCK.getMaxDistanceTravelledSq();
         } else {

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -527,7 +527,7 @@ public class TravelController {
             }
             onBlockCoord = getActiveTravelBlock(player);
             boolean onBlock = onBlockCoord != null;
-            showTargets = onBlock || isTravelItemActive(player);
+            showTargets = onBlock || isTravelItemActive(player, false);
             if (showTargets) {
                 updateSelectedTarget(player);
             } else {
@@ -615,22 +615,23 @@ public class TravelController {
         return ((IItemOfTravel) equipped.getItem()).getEnergyStored(equipped);
     }
 
-    public boolean isTravelItemActive(EntityPlayer ep) {
-        return getTravelItemTravelSource(ep) != null;
+    public boolean isTravelItemActive(EntityPlayer ep, boolean checkInventoryAndBaubles) {
+        return getTravelItemTravelSource(ep, checkInventoryAndBaubles) != null;
     }
 
     /** Returns null if no travel item is in inventory/baubles. */
     @Nullable
-    public TravelSource getTravelItemTravelSource(EntityPlayer ep) {
+    public TravelSource getTravelItemTravelSource(EntityPlayer ep, boolean checkInventoryAndBaubles) {
         if (ep == null) {
             return null;
         }
 
         ItemStack equipped = ep.getCurrentEquippedItem();
-        if (equipped == null || !(equipped.getItem() instanceof IItemOfTravel)) {
-            equipped = findTravelItemInInventoryOrBaubles(ep);
+        if(checkInventoryAndBaubles) {
+	        if (equipped == null || !(equipped.getItem() instanceof IItemOfTravel)) {
+	            equipped = findTravelItemInInventoryOrBaubles(ep);
+	        }
         }
-
         if (equipped != null) {
             if (equipped.getItem() instanceof ItemTeleportStaff) {
                 if (((ItemTeleportStaff) equipped.getItem()).isActive(ep, equipped)) {
@@ -764,7 +765,7 @@ public class TravelController {
     }
 
     public int getRequiredPower(EntityPlayer player, TravelSource source, BlockCoord coord) {
-        if (!isTravelItemActive(player)) {
+        if (!isTravelItemActive(player, true)) {
             return 0;
         }
         int requiredPower;
@@ -1063,7 +1064,7 @@ public class TravelController {
 
     @SideOnly(Side.CLIENT)
     private int getMaxTravelDistanceSqForPlayer(EntityPlayer player) {
-        TravelSource source = getTravelItemTravelSource(player);
+        TravelSource source = getTravelItemTravelSource(player,false);
         if (source == null) {
             return TravelSource.BLOCK.getMaxDistanceTravelledSq();
         }

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -627,10 +627,10 @@ public class TravelController {
         }
 
         ItemStack equipped = ep.getCurrentEquippedItem();
-        if(checkInventoryAndBaubles) {
-	        if (equipped == null || !(equipped.getItem() instanceof IItemOfTravel)) {
-	            equipped = findTravelItemInInventoryOrBaubles(ep);
-	        }
+        if (checkInventoryAndBaubles) {
+            if (equipped == null || !(equipped.getItem() instanceof IItemOfTravel)) {
+                equipped = findTravelItemInInventoryOrBaubles(ep);
+            }
         }
         if (equipped != null) {
             if (equipped.getItem() instanceof ItemTeleportStaff) {
@@ -1064,7 +1064,7 @@ public class TravelController {
 
     @SideOnly(Side.CLIENT)
     private int getMaxTravelDistanceSqForPlayer(EntityPlayer player) {
-        TravelSource source = getTravelItemTravelSource(player,false);
+        TravelSource source = getTravelItemTravelSource(player, false);
         if (source == null) {
             return TravelSource.BLOCK.getMaxDistanceTravelledSq();
         }

--- a/src/main/java/crazypants/enderio/teleport/anchor/TravelEntitySpecialRenderer.java
+++ b/src/main/java/crazypants/enderio/teleport/anchor/TravelEntitySpecialRenderer.java
@@ -69,7 +69,8 @@ public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
         Vector3d eye = Util.getEyePositionEio(Minecraft.getMinecraft().thePlayer);
         Vector3d loc = new Vector3d(tileentity.xCoord + 0.5, tileentity.yCoord + 0.5, tileentity.zCoord + 0.5);
         double maxDistance = TravelSource.BLOCK.getMaxDistanceTravelledSq();
-        TravelSource source = TravelController.instance.getTravelItemTravelSource(Minecraft.getMinecraft().thePlayer, false);
+        TravelSource source = TravelController.instance
+                .getTravelItemTravelSource(Minecraft.getMinecraft().thePlayer, false);
         if (source != null) {
             maxDistance = source.getMaxDistanceTravelledSq();
         }

--- a/src/main/java/crazypants/enderio/teleport/anchor/TravelEntitySpecialRenderer.java
+++ b/src/main/java/crazypants/enderio/teleport/anchor/TravelEntitySpecialRenderer.java
@@ -69,7 +69,7 @@ public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
         Vector3d eye = Util.getEyePositionEio(Minecraft.getMinecraft().thePlayer);
         Vector3d loc = new Vector3d(tileentity.xCoord + 0.5, tileentity.yCoord + 0.5, tileentity.zCoord + 0.5);
         double maxDistance = TravelSource.BLOCK.getMaxDistanceTravelledSq();
-        TravelSource source = TravelController.instance.getTravelItemTravelSource(Minecraft.getMinecraft().thePlayer);
+        TravelSource source = TravelController.instance.getTravelItemTravelSource(Minecraft.getMinecraft().thePlayer, false);
         if (source != null) {
             maxDistance = source.getMaxDistanceTravelledSq();
         }


### PR DESCRIPTION
Also stop inventory scanning from happening every client tick, whoops. Tested by placing a debug point on line 768 of TravelController (in getRequiredPower) and a debug point at line 656 of TravelController (in findTravelItemInInventoryOrBaubles). Debug points were used to verify that the code was ONLY hit when actual teleport happens, and not happening every tick like what was accidentally happening before.

Did retroactive testing on basic keybind functionality, held staff functionality, and anchor functionality to double-check this didn't break anything.