### PR TITLE
Fix Dark Steel Anvils in WAILA

### DIFF
--- a/src/main/java/crazypants/enderio/waila/WailaCompat.java
+++ b/src/main/java/crazypants/enderio/waila/WailaCompat.java
@@ -140,30 +140,24 @@ public class WailaCompat implements IWailaDataProvider {
     @Override
     public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
         MovingObjectPosition pos = accessor.getPosition();
-        if (config.getConfig("facades.hidden")) {
-            if (accessor.getBlock() instanceof IFacade) {
-                // If facades are hidden, we need to ignore it
-                if (accessor.getTileEntity() instanceof IConduitBundle && ConduitUtil
-                        .isFacadeHidden((IConduitBundle) accessor.getTileEntity(), accessor.getPlayer())) {
-                    return null;
-                }
-                IFacade bundle = (IFacade) accessor.getBlock();
-                Block facade = bundle.getFacade(
-                        accessor.getWorld(),
+        if (config.getConfig("facades.hidden") && accessor.getBlock() instanceof IFacade) {
+            // If facades are hidden, we need to ignore it
+            if (accessor.getTileEntity() instanceof IConduitBundle
+                    && ConduitUtil.isFacadeHidden((IConduitBundle) accessor.getTileEntity(), accessor.getPlayer())) {
+                return null;
+            }
+            IFacade bundle = (IFacade) accessor.getBlock();
+            Block facade = bundle
+                    .getFacade(accessor.getWorld(), pos.blockX, pos.blockY, pos.blockZ, accessor.getSide().ordinal());
+            if (facade != accessor.getBlock()) {
+                ItemStack ret = facade.getPickBlock(
+                        pos,
+                        new WailaWorldWrapper(accessor.getWorld()),
                         pos.blockX,
                         pos.blockY,
                         pos.blockZ,
-                        accessor.getSide().ordinal());
-                if (facade != accessor.getBlock()) {
-                    ItemStack ret = facade.getPickBlock(
-                            pos,
-                            new WailaWorldWrapper(accessor.getWorld()),
-                            pos.blockX,
-                            pos.blockY,
-                            pos.blockZ,
-                            accessor.getPlayer());
-                    return ret;
-                }
+                        accessor.getPlayer());
+                return ret;
             }
         } else if (accessor.getBlock() instanceof BlockDarkSteelAnvil) {
             return accessor.getBlock().getPickBlock(


### PR DESCRIPTION
The WAILA integration for the Dark Steel Anvil didn't work if the "Sneaky Facades" option was on (which it is by default). The integration fixes the metadata used to display the block. With "Sneaky Facades" on, if you were looking at undamaged Dark Steel Anvils facing certain directions, they would display as Slightly Damaged or Very Damaged. Slightly Damaged and Very Damaged would always display as undamaged. 

It was like this:
```java
if (config("Sneaky Facades"))
{
  if (block instanceof Facade)
  {
    ...
  }
}
else if (block instanceof Dark Steel Anvil)
{
  ...
}
```
When it should be like this:
```java
if (config("Sneaky Facades") && block instanceof Facade)
{
  ...
}
else if (block instanceof Dark Steel Anvil)
{
  ...
}
```  