### PR TITLE
Angelica compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:EnderCore:0.3.1:dev') {transitive = false}
+    api('com.github.GTNewHorizons:EnderCore:0.4.0-pre:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ForestryMC:4.8.2:dev')
     compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.5.18-GTNH:dev')
     compileOnly("com.github.GTNewHorizons:GTNHLib:0.2.4:dev")
@@ -23,4 +23,6 @@ dependencies {
     compileOnly(rfg.deobf('curse.maven:computercraft-67504:2269339')) // https://www.curseforge.com/minecraft/mc-mods/computercraft/files/2269339
     compileOnly(rfg.deobf('curse.maven:mekanism-268560:2475797')) // https://www.curseforge.com/minecraft/mc-mods/mekanism/files/2475797
     compileOnly(rfg.deobf('maven.modrinth:immibis-microblocks:59.1.2')) // https://modrinth.com/mod/immibis-microblocks/version/59.1.2
+
+    api('com.github.GTNewHorizons:Angelica:1.0.0-alpha29:api') {transitive = false}
 }

--- a/src/main/java/crazypants/enderio/ClientProxy.java
+++ b/src/main/java/crazypants/enderio/ClientProxy.java
@@ -1,8 +1,5 @@
 package crazypants.enderio;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -33,36 +30,27 @@ import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.TileConduitBundle;
 import crazypants.enderio.conduit.facade.FacadeRenderer;
 import crazypants.enderio.conduit.gas.GasConduit;
-import crazypants.enderio.conduit.gas.GasConduitRenderer;
 import crazypants.enderio.conduit.gas.GasUtil;
 import crazypants.enderio.conduit.item.ItemConduit;
 import crazypants.enderio.conduit.liquid.AbstractEnderLiquidConduit;
 import crazypants.enderio.conduit.liquid.AdvancedLiquidConduit;
-import crazypants.enderio.conduit.liquid.AdvancedLiquidConduitRenderer;
 import crazypants.enderio.conduit.liquid.CrystallineEnderLiquidConduit;
 import crazypants.enderio.conduit.liquid.CrystallinePinkSlimeEnderLiquidConduit;
 import crazypants.enderio.conduit.liquid.EnderLiquidConduit;
-import crazypants.enderio.conduit.liquid.EnderLiquidConduitRenderer;
 import crazypants.enderio.conduit.liquid.LiquidConduit;
-import crazypants.enderio.conduit.liquid.LiquidConduitRenderer;
 import crazypants.enderio.conduit.liquid.MelodicEnderLiquidConduit;
 import crazypants.enderio.conduit.liquid.StellarEnderLiquidConduit;
 import crazypants.enderio.conduit.me.MEConduit;
 import crazypants.enderio.conduit.me.MEUtil;
 import crazypants.enderio.conduit.oc.OCConduit;
-import crazypants.enderio.conduit.oc.OCConduitRenderer;
 import crazypants.enderio.conduit.oc.OCUtil;
 import crazypants.enderio.conduit.power.PowerConduit;
-import crazypants.enderio.conduit.power.PowerConduitRenderer;
 import crazypants.enderio.conduit.power.endergy.PowerConduitEndergy;
 import crazypants.enderio.conduit.redstone.InsulatedRedstoneConduit;
-import crazypants.enderio.conduit.redstone.InsulatedRedstoneConduitRenderer;
 import crazypants.enderio.conduit.redstone.RedstoneConduit;
 import crazypants.enderio.conduit.redstone.RedstoneSwitch;
-import crazypants.enderio.conduit.redstone.RedstoneSwitchRenderer;
 import crazypants.enderio.conduit.render.ConduitBundleRenderer;
 import crazypants.enderio.conduit.render.ConduitRenderer;
-import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 import crazypants.enderio.conduit.render.ItemConduitRenderer;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.enderface.EnderIoRenderer;
@@ -165,10 +153,6 @@ public class ClientProxy extends CommonProxy {
         {5, 4, 5, 4, 2, 3}
     };
     // @formatter:on
-
-    private final List<ConduitRenderer> conduitRenderers = new ArrayList<ConduitRenderer>();
-
-    private final DefaultConduitRenderer dcr = new DefaultConduitRenderer();
 
     private ConduitBundleRenderer cbr;
 
@@ -403,20 +387,6 @@ public class ClientProxy extends CommonProxy {
         RenderingRegistry.registerBlockHandler(esk);
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(EnderIO.blockEndermanSkull), esk);
 
-        conduitRenderers.add(RedstoneSwitchRenderer.getInstance());
-        conduitRenderers.add(new AdvancedLiquidConduitRenderer());
-        conduitRenderers.add(LiquidConduitRenderer.create());
-        conduitRenderers.add(new PowerConduitRenderer());
-        conduitRenderers.add(new InsulatedRedstoneConduitRenderer());
-        conduitRenderers.add(new EnderLiquidConduitRenderer());
-        conduitRenderers.add(new crazypants.enderio.conduit.item.ItemConduitRenderer());
-        if (GasUtil.isGasConduitEnabled()) {
-            conduitRenderers.add(new GasConduitRenderer());
-        }
-        if (OCUtil.isOCEnabled()) {
-            conduitRenderers.add(new OCConduitRenderer());
-        }
-
         EnderIoRenderer eior = new EnderIoRenderer();
         ClientRegistry.bindTileEntitySpecialRenderer(TileEnderIO.class, eior);
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(EnderIO.blockEnderIo), eior);
@@ -480,12 +450,7 @@ public class ClientProxy extends CommonProxy {
 
     @Override
     public ConduitRenderer getRendererForConduit(IConduit conduit) {
-        for (ConduitRenderer renderer : conduitRenderers) {
-            if (renderer.isRendererForConduit(conduit)) {
-                return renderer;
-            }
-        }
-        return dcr;
+        return conduit.getRenderer();
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/CommonProxy.java
+++ b/src/main/java/crazypants/enderio/CommonProxy.java
@@ -34,6 +34,7 @@ public class CommonProxy {
         return null;
     }
 
+    @Deprecated
     public ConduitRenderer getRendererForConduit(IConduit conduit) {
         return null;
     }

--- a/src/main/java/crazypants/enderio/conduit/ConduitUtil.java
+++ b/src/main/java/crazypants/enderio/conduit/ConduitUtil.java
@@ -158,7 +158,7 @@ public class ConduitUtil {
     }
 
     public static boolean isFacadeHidden(IConduitBundle bundle, EntityPlayer player) {
-        return bundle.getFacadeId() != null && shouldHeldItemHideFacades(player);
+        return bundle != null && bundle.getFacadeId() != null && shouldHeldItemHideFacades(player);
     }
 
     public static ConduitDisplayMode getDisplayMode(EntityPlayer player) {

--- a/src/main/java/crazypants/enderio/conduit/IConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/IConduit.java
@@ -17,6 +17,7 @@ import com.enderio.core.common.util.BlockCoord;
 
 import crazypants.enderio.conduit.geom.CollidableCache.CacheKey;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 
 public interface IConduit {
 
@@ -141,4 +142,6 @@ public interface IConduit {
      * Should the texture of the conduit connectors be mirrored around the conduit node?
      */
     boolean shouldMirrorTexture();
+
+    ConduitRenderer getRenderer();
 }

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -428,7 +428,7 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
         if (worldObj.isRemote) {
             return;
         }
-        List<IConduit> copy = new ArrayList<IConduit>(conduits);
+        List<IConduit> copy = new ArrayList<>(conduits);
         for (IConduit con : copy) {
             removeConduit(con, false);
         }

--- a/src/main/java/crazypants/enderio/conduit/facade/BlockConduitFacade.java
+++ b/src/main/java/crazypants/enderio/conduit/facade/BlockConduitFacade.java
@@ -16,12 +16,16 @@ import crazypants.enderio.ModObject;
 import crazypants.enderio.conduit.IConduitBundle;
 import crazypants.enderio.machine.painter.IPaintedBlock;
 
-public class BlockConduitFacade extends BlockEio implements IPaintedBlock {
+public class BlockConduitFacade extends BlockEio implements IPaintedBlock, Cloneable {
 
     public static BlockConduitFacade create() {
         BlockConduitFacade result = new BlockConduitFacade();
         result.init();
         return result;
+    }
+
+    public BlockConduitFacade clone() throws CloneNotSupportedException {
+        return (BlockConduitFacade) super.clone();
     }
 
     private Block blockOverride;

--- a/src/main/java/crazypants/enderio/conduit/gas/GasConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/gas/GasConduit.java
@@ -20,6 +20,7 @@ import crazypants.enderio.conduit.AbstractConduitNetwork;
 import crazypants.enderio.conduit.ConnectionMode;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.config.Config;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
@@ -34,7 +35,12 @@ public class GasConduit extends AbstractGasTankConduit {
     public static final String ICON_INSERT_KEY = "enderio:gasConduitOutput";
     public static final String ICON_EMPTY_EDGE = "enderio:gasConduitEdge";
 
-    static final Map<String, IIcon> ICONS = new HashMap<String, IIcon>();
+    static final Map<String, IIcon> ICONS = new HashMap<>();
+
+    @Override
+    public ConduitRenderer getRenderer() {
+        return GasConduitRenderer.instance.get();
+    }
 
     @SideOnly(Side.CLIENT)
     public static void initIcons() {

--- a/src/main/java/crazypants/enderio/conduit/gas/GasConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/gas/GasConduitRenderer.java
@@ -1,15 +1,13 @@
 package crazypants.enderio.conduit.gas;
 
-import static com.enderio.core.client.render.CubeRenderer.addVecWithUV;
-
 import java.util.List;
 
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.enderio.core.client.render.BoundingBox;
+import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.RenderUtil;
 import com.enderio.core.common.vecmath.Vector3d;
 import com.enderio.core.common.vecmath.Vertex;
@@ -22,15 +20,13 @@ import crazypants.enderio.conduit.geom.CollidableComponent;
 import crazypants.enderio.conduit.geom.ConnectionModeGeometry;
 import crazypants.enderio.conduit.geom.Offset;
 import crazypants.enderio.conduit.render.ConduitBundleRenderer;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 import mekanism.api.gas.GasStack;
 
 public class GasConduitRenderer extends DefaultConduitRenderer {
 
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        return conduit instanceof GasConduit;
-    }
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal.withInitial(GasConduitRenderer::new);
 
     @Override
     public void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit, double x,
@@ -58,6 +54,8 @@ public class GasConduitRenderer extends DefaultConduitRenderer {
     @Override
     protected void renderConduit(IIcon tex, IConduit conduit, CollidableComponent component, float brightness) {
         super.renderConduit(tex, conduit, component, brightness);
+        final CubeRenderer cr = CubeRenderer.get();
+        int i;
 
         if (isNSEWUD(component.dir)) {
             GasConduit lc = (GasConduit) conduit;
@@ -103,15 +101,17 @@ public class GasConduitRenderer extends DefaultConduitRenderer {
                     List<Vertex> corners = bb.getCornersWithUvForFace(d, minU, maxU, minV, maxV);
                     moveEdgeCorners(corners, vDir, width);
                     moveEdgeCorners(corners, component.dir.getOpposite(), sideScale);
-                    for (Vertex c : corners) {
-                        addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                    for (i = 0; i < corners.size(); i++) {
+                        final Vertex c = corners.get(i);
+                        cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                     }
 
                     corners = bb.getCornersWithUvForFace(d, minU, maxU, minV, maxV);
                     moveEdgeCorners(corners, vDir.getOpposite(), width);
                     moveEdgeCorners(corners, component.dir.getOpposite(), sideScale);
-                    for (Vertex c : corners) {
-                        addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                    for (i = 0; i < corners.size(); i++) {
+                        final Vertex c = corners.get(i);
+                        cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                     }
                 }
             }
@@ -124,14 +124,15 @@ public class GasConduitRenderer extends DefaultConduitRenderer {
                         tex.getMaxU(),
                         tex.getMinV(),
                         tex.getMaxV());
-                Tessellator tessellator = Tessellator.instance;
-                for (Vertex c : corners) {
-                    addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+
+                for (i = 0; i < corners.size(); i++) {
+                    final Vertex c = corners.get(i);
+                    cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                 }
                 // back face
-                for (int i = corners.size() - 1; i >= 0; i--) {
-                    Vertex c = corners.get(i);
-                    addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                for (i = corners.size() - 1; i >= 0; i--) {
+                    final Vertex c = corners.get(i);
+                    cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                 }
             }
         }

--- a/src/main/java/crazypants/enderio/conduit/item/IItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/item/IItemConduit.java
@@ -11,8 +11,14 @@ import cofh.api.transport.IItemDuct;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.IExtractor;
 import crazypants.enderio.conduit.item.filter.IItemFilter;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 
 public interface IItemConduit extends IConduit, IItemDuct, IExtractor {
+
+    @Override
+    default ConduitRenderer getRenderer() {
+        return ItemConduitRenderer.instance.get();
+    }
 
     IIcon getTextureForInputMode();
 

--- a/src/main/java/crazypants/enderio/conduit/item/ItemConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/item/ItemConduitRenderer.java
@@ -13,17 +13,12 @@ import crazypants.enderio.conduit.IConduitBundle;
 import crazypants.enderio.conduit.geom.ConnectionModeGeometry;
 import crazypants.enderio.conduit.geom.Offset;
 import crazypants.enderio.conduit.render.ConduitBundleRenderer;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 
 public class ItemConduitRenderer extends DefaultConduitRenderer {
 
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        if (conduit instanceof IItemConduit) {
-            return true;
-        }
-        return false;
-    }
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal.withInitial(ItemConduitRenderer::new);
 
     @Override
     public void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit, double x,

--- a/src/main/java/crazypants/enderio/conduit/liquid/AbstractEnderLiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/AbstractEnderLiquidConduit.java
@@ -34,6 +34,7 @@ import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.RaytraceResult;
 import crazypants.enderio.conduit.geom.CollidableComponent;
 import crazypants.enderio.conduit.item.ItemConduit;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.RedstoneControlMode;
 import crazypants.enderio.tool.ToolUtil;
@@ -46,8 +47,13 @@ public abstract class AbstractEnderLiquidConduit extends AbstractLiquidConduit {
     public static final String ICON_KEY_IN_OUT_OUT = ItemConduit.ICON_KEY_IN_OUT_OUT;
     public static final String ICON_KEY_IN_OUT_IN = ItemConduit.ICON_KEY_IN_OUT_IN;
 
-    static final Map<String, IIcon> ICONS = new HashMap<String, IIcon>();
+    static final Map<String, IIcon> ICONS = new HashMap<>();
     private final Set<BlockCoord> filledFromThisTick = new HashSet<>();
+
+    @Override
+    public ConduitRenderer getRenderer() {
+        return EnderLiquidConduitRenderer.instance.get();
+    }
 
     @SideOnly(Side.CLIENT)
     public static void initIcons() {

--- a/src/main/java/crazypants/enderio/conduit/liquid/AdvancedLiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/AdvancedLiquidConduit.java
@@ -23,6 +23,7 @@ import crazypants.enderio.conduit.AbstractConduitNetwork;
 import crazypants.enderio.conduit.ConnectionMode;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.RedstoneControlMode;
 
@@ -37,7 +38,12 @@ public class AdvancedLiquidConduit extends AbstractTankConduit {
     public static final String ICON_INSERT_KEY = "enderio:liquidConduitAdvancedOutput";
     public static final String ICON_EMPTY_EDGE = "enderio:liquidConduitAdvancedEdge";
 
-    static final Map<String, IIcon> ICONS = new HashMap<String, IIcon>();
+    static final Map<String, IIcon> ICONS = new HashMap<>();
+
+    @Override
+    public ConduitRenderer getRenderer() {
+        return AdvancedLiquidConduitRenderer.instance.get();
+    }
 
     @SideOnly(Side.CLIENT)
     public static void initIcons() {

--- a/src/main/java/crazypants/enderio/conduit/liquid/AdvancedLiquidConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/AdvancedLiquidConduitRenderer.java
@@ -1,16 +1,14 @@
 package crazypants.enderio.conduit.liquid;
 
-import static com.enderio.core.client.render.CubeRenderer.addVecWithUV;
-
 import java.util.List;
 
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.enderio.core.client.render.BoundingBox;
+import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.RenderUtil;
 import com.enderio.core.common.vecmath.Vector3d;
 import com.enderio.core.common.vecmath.Vertex;
@@ -23,14 +21,13 @@ import crazypants.enderio.conduit.geom.CollidableComponent;
 import crazypants.enderio.conduit.geom.ConnectionModeGeometry;
 import crazypants.enderio.conduit.geom.Offset;
 import crazypants.enderio.conduit.render.ConduitBundleRenderer;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 
 public class AdvancedLiquidConduitRenderer extends DefaultConduitRenderer {
 
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        return conduit instanceof AdvancedLiquidConduit;
-    }
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal
+            .withInitial(AdvancedLiquidConduitRenderer::new);
 
     @Override
     public void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit, double x,
@@ -58,6 +55,8 @@ public class AdvancedLiquidConduitRenderer extends DefaultConduitRenderer {
     @Override
     protected void renderConduit(IIcon tex, IConduit conduit, CollidableComponent component, float brightness) {
         super.renderConduit(tex, conduit, component, brightness);
+        final CubeRenderer cr = CubeRenderer.get();
+        int i;
 
         if (isNSEWUD(component.dir)) {
             AdvancedLiquidConduit lc = (AdvancedLiquidConduit) conduit;
@@ -106,15 +105,17 @@ public class AdvancedLiquidConduitRenderer extends DefaultConduitRenderer {
                     List<Vertex> corners = bb.getCornersWithUvForFace(d, minU, maxU, minV, maxV);
                     moveEdgeCorners(corners, vDir, width);
                     moveEdgeCorners(corners, component.dir.getOpposite(), sideScale);
-                    for (Vertex c : corners) {
-                        addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                    for (i = 0; i < corners.size(); i++) {
+                        final Vertex c = corners.get(i);
+                        cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                     }
 
                     corners = bb.getCornersWithUvForFace(d, minU, maxU, minV, maxV);
                     moveEdgeCorners(corners, vDir.getOpposite(), width);
                     moveEdgeCorners(corners, component.dir.getOpposite(), sideScale);
-                    for (Vertex c : corners) {
-                        addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                    for (i = 0; i < corners.size(); i++) {
+                        final Vertex c = corners.get(i);
+                        cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                     }
                 }
             }
@@ -127,14 +128,14 @@ public class AdvancedLiquidConduitRenderer extends DefaultConduitRenderer {
                         tex.getMaxU(),
                         tex.getMinV(),
                         tex.getMaxV());
-                Tessellator tessellator = Tessellator.instance;
-                for (Vertex c : corners) {
-                    addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                for (i = 0; i < corners.size(); i++) {
+                    final Vertex c = corners.get(i);
+                    cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                 }
                 // back face
-                for (int i = corners.size() - 1; i >= 0; i--) {
+                for (i = corners.size() - 1; i >= 0; i--) {
                     Vertex c = corners.get(i);
-                    addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                    cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                 }
             }
         }

--- a/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduitRenderer.java
@@ -13,17 +13,13 @@ import crazypants.enderio.conduit.IConduitBundle;
 import crazypants.enderio.conduit.geom.ConnectionModeGeometry;
 import crazypants.enderio.conduit.geom.Offset;
 import crazypants.enderio.conduit.render.ConduitBundleRenderer;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 
 public class EnderLiquidConduitRenderer extends DefaultConduitRenderer {
 
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        if (conduit instanceof AbstractEnderLiquidConduit) {
-            return true;
-        }
-        return false;
-    }
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal
+            .withInitial(EnderLiquidConduitRenderer::new);
 
     @Override
     public void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit, double x,

--- a/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduit.java
@@ -27,6 +27,7 @@ import crazypants.enderio.conduit.ConduitUtil;
 import crazypants.enderio.conduit.ConnectionMode;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.network.PacketHandler;
 
@@ -42,7 +43,12 @@ public class LiquidConduit extends AbstractTankConduit {
     public static final String ICON_INSERT_KEY = "enderio:liquidConduitInsert";
     public static final String ICON_EMPTY_INSERT_KEY = "enderio:emptyLiquidConduitInsert";
 
-    static final Map<String, IIcon> ICONS = new HashMap<String, IIcon>();
+    static final Map<String, IIcon> ICONS = new HashMap<>();
+
+    @Override
+    public ConduitRenderer getRenderer() {
+        return LiquidConduitRenderer.instance.get();
+    }
 
     @SideOnly(Side.CLIENT)
     public static void initIcons() {

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduit.java
@@ -33,9 +33,16 @@ import crazypants.enderio.conduit.IConduitBundle;
 import crazypants.enderio.conduit.RaytraceResult;
 import crazypants.enderio.conduit.TileConduitBundle;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.render.ConduitRenderer;
+import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 import crazypants.enderio.tool.ToolUtil;
 
 public class MEConduit extends AbstractConduit implements IMEConduit {
+
+    @Override
+    public ConduitRenderer getRenderer() {
+        return DefaultConduitRenderer.instance.get();
+    }
 
     protected MEConduitNetwork network;
     protected MEConduitGrid grid;

--- a/src/main/java/crazypants/enderio/conduit/oc/IOCConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/oc/IOCConduit.java
@@ -7,6 +7,7 @@ import com.enderio.core.common.util.DyeColor;
 import cpw.mods.fml.common.Optional.Interface;
 import cpw.mods.fml.common.Optional.InterfaceList;
 import crazypants.enderio.conduit.IConduit;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import li.cil.oc.api.network.Environment;
 import li.cil.oc.api.network.SidedEnvironment;
 
@@ -14,11 +15,16 @@ import li.cil.oc.api.network.SidedEnvironment;
         @Interface(iface = "li.cil.oc.api.network.SidedEnvironment", modid = "OpenComputersAPI|Network") })
 public interface IOCConduit extends IConduit, Environment, SidedEnvironment {
 
-    public static final String COLOR_CONTROLLER_ID = "ColorController";
+    String COLOR_CONTROLLER_ID = "ColorController";
+
+    @Override
+    default ConduitRenderer getRenderer() {
+        return OCConduitRenderer.instance.get();
+    }
 
     void invalidate();
 
-    public abstract void setSignalColor(ForgeDirection dir, DyeColor col);
+    void setSignalColor(ForgeDirection dir, DyeColor col);
 
-    public abstract DyeColor getSignalColor(ForgeDirection dir);
+    DyeColor getSignalColor(ForgeDirection dir);
 }

--- a/src/main/java/crazypants/enderio/conduit/oc/OCConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/oc/OCConduitRenderer.java
@@ -7,14 +7,12 @@ import com.enderio.core.client.render.CubeRenderer;
 
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 
 public class OCConduitRenderer extends DefaultConduitRenderer {
 
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        return conduit instanceof IOCConduit;
-    }
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal.withInitial(OCConduitRenderer::new);
 
     @Override
     protected void renderConduit(IIcon tex, IConduit conduit, CollidableComponent component, float selfIllum) {
@@ -23,7 +21,7 @@ public class OCConduitRenderer extends DefaultConduitRenderer {
                 int c = ((IOCConduit) conduit).getSignalColor(component.dir).getColor();
                 Tessellator tessellator = Tessellator.instance;
                 tessellator.setColorOpaque_I(c);
-                CubeRenderer.render(component.bound, tex);
+                CubeRenderer.get().render(component.bound, tex);
                 tessellator.setColorOpaque(255, 255, 255);
             }
         } else {

--- a/src/main/java/crazypants/enderio/conduit/power/IPowerConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/power/IPowerConduit.java
@@ -5,19 +5,25 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.IExtractor;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.power.ICapacitor;
 import crazypants.enderio.power.IInternalPowerHandler;
 import crazypants.enderio.power.IPowerInterface;
 
 public interface IPowerConduit extends IConduit, IInternalPowerHandler, IExtractor {
 
-    public static final String ICON_KEY = "enderio:powerConduit";
-    public static final String ICON_KEY_INPUT = "enderio:powerConduitInput";
-    public static final String ICON_KEY_OUTPUT = "enderio:powerConduitOutput";
-    public static final String ICON_CORE_KEY = "enderio:powerConduitCore";
-    public static final String ICON_TRANSMISSION_KEY = "enderio:powerConduitTransmission";
+    String ICON_KEY = "enderio:powerConduit";
+    String ICON_KEY_INPUT = "enderio:powerConduitInput";
+    String ICON_KEY_OUTPUT = "enderio:powerConduitOutput";
+    String ICON_CORE_KEY = "enderio:powerConduitCore";
+    String ICON_TRANSMISSION_KEY = "enderio:powerConduitTransmission";
 
-    public static final String COLOR_CONTROLLER_ID = "ColorController";
+    String COLOR_CONTROLLER_ID = "ColorController";
+
+    @Override
+    default ConduitRenderer getRenderer() {
+        return PowerConduitRenderer.instance.get();
+    }
 
     IPowerInterface getExternalPowerReceptor(ForgeDirection direction);
 

--- a/src/main/java/crazypants/enderio/conduit/power/PowerConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/power/PowerConduitRenderer.java
@@ -17,15 +17,13 @@ import crazypants.enderio.conduit.geom.CollidableComponent;
 import crazypants.enderio.conduit.geom.ConnectionModeGeometry;
 import crazypants.enderio.conduit.geom.Offset;
 import crazypants.enderio.conduit.render.ConduitBundleRenderer;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 import crazypants.enderio.machine.RedstoneControlMode;
 
 public class PowerConduitRenderer extends DefaultConduitRenderer {
 
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        return conduit instanceof IPowerConduit;
-    }
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal.withInitial(PowerConduitRenderer::new);
 
     @Override
     public void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit, double x,
@@ -68,7 +66,7 @@ public class PowerConduitRenderer extends DefaultConduitRenderer {
                     Vector3d trans = ForgeDirectionOffsets.offsetScaled(component.dir, -0.075);
                     bound = bound.translate(trans);
                 }
-                CubeRenderer.render(bound, tex);
+                CubeRenderer.get().render(bound, tex);
                 tessellator.setColorOpaque(255, 255, 255);
             }
         } else {

--- a/src/main/java/crazypants/enderio/conduit/redstone/IInsulatedRedstoneConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/IInsulatedRedstoneConduit.java
@@ -5,14 +5,20 @@ import net.minecraftforge.common.util.ForgeDirection;
 import com.enderio.core.common.util.DyeColor;
 
 import crazypants.enderio.conduit.ConnectionMode;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 
 public interface IInsulatedRedstoneConduit extends IRedstoneConduit {
 
-    static final String KEY_INS_CONDUIT_ICON = "enderio:redstoneInsulatedConduit";
-    static final String KEY_INS_CORE_OFF_ICON = "enderio:redstoneInsulatedConduitCoreOff";
-    static final String KEY_INS_CORE_ON_ICON = "enderio:redstoneInsulatedConduitCoreOn";
+    String KEY_INS_CONDUIT_ICON = "enderio:redstoneInsulatedConduit";
+    String KEY_INS_CORE_OFF_ICON = "enderio:redstoneInsulatedConduitCoreOff";
+    String KEY_INS_CORE_ON_ICON = "enderio:redstoneInsulatedConduitCoreOn";
 
-    public static final String COLOR_CONTROLLER_ID = "ColorController";
+    String COLOR_CONTROLLER_ID = "ColorController";
+
+    @Override
+    default ConduitRenderer getRenderer() {
+        return InsulatedRedstoneConduitRenderer.instance.get();
+    }
 
     void onInputsChanged(ForgeDirection side, int[] inputValues);
 

--- a/src/main/java/crazypants/enderio/conduit/redstone/InsulatedRedstoneConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/InsulatedRedstoneConduitRenderer.java
@@ -7,14 +7,13 @@ import com.enderio.core.client.render.CubeRenderer;
 
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 
 public class InsulatedRedstoneConduitRenderer extends DefaultConduitRenderer {
 
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        return conduit instanceof IInsulatedRedstoneConduit;
-    }
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal
+            .withInitial(InsulatedRedstoneConduitRenderer::new);
 
     @Override
     protected void renderConduit(IIcon tex, IConduit conduit, CollidableComponent component, float selfIllum) {
@@ -24,7 +23,7 @@ public class InsulatedRedstoneConduitRenderer extends DefaultConduitRenderer {
                 int c = ((IInsulatedRedstoneConduit) conduit).getSignalColor(component.dir).getColor();
                 Tessellator tessellator = Tessellator.instance;
                 tessellator.setColorOpaque_I(c);
-                CubeRenderer.render(component.bound, tex);
+                CubeRenderer.get().render(component.bound, tex);
                 tessellator.setColorOpaque(255, 255, 255);
             }
         } else {

--- a/src/main/java/crazypants/enderio/conduit/redstone/RedstoneConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/RedstoneConduit.java
@@ -33,12 +33,19 @@ import crazypants.enderio.conduit.AbstractConduitNetwork;
 import crazypants.enderio.conduit.ConduitUtil;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.geom.CollidableComponent;
+import crazypants.enderio.conduit.render.ConduitRenderer;
+import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 import dan200.computercraft.api.ComputerCraftAPI;
 import powercrystals.minefactoryreloaded.api.rednet.IRedNetOutputNode;
 
 public class RedstoneConduit extends AbstractConduit implements IRedstoneConduit {
 
-    static final Map<String, IIcon> ICONS = new HashMap<String, IIcon>();
+    static final Map<String, IIcon> ICONS = new HashMap<>();
+
+    @Override
+    public ConduitRenderer getRenderer() {
+        return DefaultConduitRenderer.instance.get();
+    }
 
     @SideOnly(Side.CLIENT)
     public static void initIcons() {

--- a/src/main/java/crazypants/enderio/conduit/redstone/RedstoneSwitch.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/RedstoneSwitch.java
@@ -24,6 +24,7 @@ import crazypants.enderio.conduit.RaytraceResult;
 import crazypants.enderio.conduit.geom.CollidableComponent;
 import crazypants.enderio.conduit.geom.ConduitGeometryUtil;
 import crazypants.enderio.conduit.geom.Offset;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 
 public class RedstoneSwitch extends RedstoneConduit {
 
@@ -32,6 +33,11 @@ public class RedstoneSwitch extends RedstoneConduit {
     public static final String SWITCH_ICON_ON_KEY = "enderio:redstoneConduitSwitchOn";
 
     private boolean isOn;
+
+    @Override
+    public ConduitRenderer getRenderer() {
+        return RedstoneSwitchRenderer.instance.get();
+    }
 
     @SideOnly(Side.CLIENT)
     public static void initIcons() {
@@ -97,7 +103,7 @@ public class RedstoneSwitch extends RedstoneConduit {
         Vector3d trans = ConduitGeometryUtil.instance.getTranslation(ForgeDirection.UNKNOWN, o);
 
         List<CollidableComponent> result = super.getCollidableComponents();
-        BoundingBox[] aabb = RedstoneSwitchBounds.getInstance().getAABB();
+        BoundingBox[] aabb = RedstoneSwitchBounds.get().getAABB();
 
         for (BoundingBox bb : aabb) {
             result.add(

--- a/src/main/java/crazypants/enderio/conduit/redstone/RedstoneSwitchBounds.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/RedstoneSwitchBounds.java
@@ -9,13 +9,11 @@ import crazypants.enderio.config.Config;
 
 public class RedstoneSwitchBounds {
 
-    private static RedstoneSwitchBounds instance;
+    private static final ThreadLocal<RedstoneSwitchBounds> instance = ThreadLocal
+            .withInitial(RedstoneSwitchBounds::new);
 
-    public static final RedstoneSwitchBounds getInstance() {
-        if (instance == null) {
-            instance = new RedstoneSwitchBounds();
-        }
-        return instance;
+    public static RedstoneSwitchBounds get() {
+        return RedstoneSwitchBounds.instance.get();
     }
 
     final VertexTransform[] xForms;

--- a/src/main/java/crazypants/enderio/conduit/redstone/RedstoneSwitchRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/RedstoneSwitchRenderer.java
@@ -17,29 +17,21 @@ import crazypants.enderio.conduit.geom.CollidableComponent;
 import crazypants.enderio.conduit.geom.ConduitConnectorType;
 import crazypants.enderio.conduit.geom.ConduitGeometryUtil;
 import crazypants.enderio.conduit.render.ConduitBundleRenderer;
+import crazypants.enderio.conduit.render.ConduitRenderer;
 import crazypants.enderio.conduit.render.DefaultConduitRenderer;
 
 public class RedstoneSwitchRenderer extends DefaultConduitRenderer {
 
-    private static final RedstoneSwitchRenderer instance = new RedstoneSwitchRenderer();
-
-    public static RedstoneSwitchRenderer getInstance() {
-        return instance;
-    }
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal.withInitial(RedstoneSwitchRenderer::new);
 
     private final VertexTransform[] xForms;
     private final BoundingBox switchBounds;
     private final BoundingBox connectorBounds;
 
-    private RedstoneSwitchRenderer() {
-        xForms = RedstoneSwitchBounds.getInstance().xForms;
-        switchBounds = RedstoneSwitchBounds.getInstance().switchBounds;
-        connectorBounds = RedstoneSwitchBounds.getInstance().connectorBounds;
-    }
-
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        return conduit.getClass() == RedstoneSwitch.class;
+    public RedstoneSwitchRenderer() {
+        xForms = RedstoneSwitchBounds.get().xForms;
+        switchBounds = RedstoneSwitchBounds.get().switchBounds;
+        connectorBounds = RedstoneSwitchBounds.get().connectorBounds;
     }
 
     @Override
@@ -49,13 +41,15 @@ public class RedstoneSwitchRenderer extends DefaultConduitRenderer {
         super.renderEntity(conduitBundleRenderer, bundle, conduit, x, y, z, partialTick, worldLight, rb);
 
         RedstoneSwitch sw = (RedstoneSwitch) conduit;
+        int i;
 
-        Tessellator tessellator = Tessellator.instance;
+        final Tessellator tessellator = Tessellator.instance;
+        final CubeRenderer cr = CubeRenderer.get();
         float selfIllum = Math.max(worldLight, conduit.getSelfIlluminationForState(null));
         tessellator.setColorOpaque_F(selfIllum, selfIllum, selfIllum);
 
         IIcon[] icons = new IIcon[6];
-        for (int i = 0; i < icons.length; i++) {
+        for (i = 0; i < icons.length; i++) {
             icons[i] = EnderIO.blockConduitBundle.getConnectorIcon(ConduitConnectorType.INTERNAL);
         }
         icons[3] = sw.getSwitchIcon();
@@ -65,12 +59,12 @@ public class RedstoneSwitchRenderer extends DefaultConduitRenderer {
                 bundle.getOffset(IRedstoneConduit.class, ForgeDirection.UNKNOWN));
         BoundingBox bb = switchBounds.translate(trans);
 
-        for (VertexTransform tf : xForms) {
-            CubeRenderer.render(bb, icons, tf, null);
+        for (i = 0; i < xForms.length; i++) {
+            cr.render(bb, icons, xForms[i], null);
         }
         bb = connectorBounds.translate(trans);
-        for (VertexTransform tf : xForms) {
-            CubeRenderer.render(bb, icons[0], tf);
+        for (i = 0; i < xForms.length; i++) {
+            cr.render(bb, icons[0], xForms[i]);
         }
     }
 

--- a/src/main/java/crazypants/enderio/conduit/render/ConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/ConduitRenderer.java
@@ -7,8 +7,6 @@ import crazypants.enderio.conduit.IConduitBundle;
 
 public interface ConduitRenderer {
 
-    boolean isRendererForConduit(IConduit conduit);
-
     void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit con, double x, double y,
             double z, float partialTick, float worldLight, RenderBlocks rb);
 

--- a/src/main/java/crazypants/enderio/conduit/render/DefaultConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/DefaultConduitRenderer.java
@@ -1,8 +1,5 @@
 package crazypants.enderio.conduit.render;
 
-import static com.enderio.core.client.render.CubeRenderer.addVecWithUV;
-import static com.enderio.core.client.render.CubeRenderer.setupVertices;
-import static com.enderio.core.client.render.CubeRenderer.verts;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 import static net.minecraftforge.common.util.ForgeDirection.EAST;
 import static net.minecraftforge.common.util.ForgeDirection.NORTH;
@@ -19,6 +16,7 @@ import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.enderio.core.client.render.BoundingBox;
+import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.RenderUtil;
 import com.enderio.core.common.vecmath.Vertex;
 
@@ -30,12 +28,9 @@ import crazypants.enderio.conduit.geom.CollidableComponent;
 
 public class DefaultConduitRenderer implements ConduitRenderer {
 
-    protected float transmissionScaleFactor;
+    public static final ThreadLocal<ConduitRenderer> instance = ThreadLocal.withInitial(DefaultConduitRenderer::new);
 
-    @Override
-    public boolean isRendererForConduit(IConduit conduit) {
-        return true;
-    }
+    protected float transmissionScaleFactor;
 
     @Override
     public void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit, double x,
@@ -73,6 +68,7 @@ public class DefaultConduitRenderer implements ConduitRenderer {
             double x, double y, double z, float partialTick, float worldLight) {}
 
     protected void renderConduit(IIcon tex, IConduit conduit, CollidableComponent component, float brightness) {
+        final CubeRenderer cr = CubeRenderer.get();
 
         if (isNSEWUD(component.dir)) {
 
@@ -103,7 +99,7 @@ public class DefaultConduitRenderer implements ConduitRenderer {
                         tex.getMaxV());
                 Tessellator tessellator = Tessellator.instance;
                 for (Vertex c : corners) {
-                    addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                    cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                 }
             }
 
@@ -150,12 +146,13 @@ public class DefaultConduitRenderer implements ConduitRenderer {
     protected void drawSection(BoundingBox bound, float minU, float maxU, float minV, float maxV, ForgeDirection dir,
             boolean isTransmission, boolean mirrorTexture) {
 
-        Tessellator tessellator = Tessellator.instance;
+        final Tessellator tessellator = Tessellator.instance;
+        final CubeRenderer cr = CubeRenderer.get();
 
         if (isTransmission) {
             setVerticesForTransmission(bound, dir);
         } else {
-            setupVertices(bound);
+            cr.setupVertices(bound);
         }
 
         if (mirrorTexture && (dir == NORTH || dir == UP || dir == EAST)) {
@@ -175,15 +172,15 @@ public class DefaultConduitRenderer implements ConduitRenderer {
                 tessellator.setColorOpaque_F(cm, cm, cm);
             }
             if (rotateSides) {
-                addVecWithUV(verts[1], maxU, maxV);
-                addVecWithUV(verts[0], maxU, minV);
-                addVecWithUV(verts[3], minU, minV);
-                addVecWithUV(verts[2], minU, maxV);
+                cr.addVecWithUV(cr.verts[1], maxU, maxV);
+                cr.addVecWithUV(cr.verts[0], maxU, minV);
+                cr.addVecWithUV(cr.verts[3], minU, minV);
+                cr.addVecWithUV(cr.verts[2], minU, maxV);
             } else {
-                addVecWithUV(verts[1], minU, minV);
-                addVecWithUV(verts[0], maxU, minV);
-                addVecWithUV(verts[3], maxU, maxV);
-                addVecWithUV(verts[2], minU, maxV);
+                cr.addVecWithUV(cr.verts[1], minU, minV);
+                cr.addVecWithUV(cr.verts[0], maxU, minV);
+                cr.addVecWithUV(cr.verts[3], maxU, maxV);
+                cr.addVecWithUV(cr.verts[2], minU, maxV);
             }
             if (dir == WEST || dir == EAST) {
                 float tmp = minU;
@@ -196,15 +193,15 @@ public class DefaultConduitRenderer implements ConduitRenderer {
                 tessellator.setColorOpaque_F(cm, cm, cm);
             }
             if (rotateSides) {
-                addVecWithUV(verts[4], maxU, maxV);
-                addVecWithUV(verts[5], maxU, minV);
-                addVecWithUV(verts[6], minU, minV);
-                addVecWithUV(verts[7], minU, maxV);
+                cr.addVecWithUV(cr.verts[4], maxU, maxV);
+                cr.addVecWithUV(cr.verts[5], maxU, minV);
+                cr.addVecWithUV(cr.verts[6], minU, minV);
+                cr.addVecWithUV(cr.verts[7], minU, maxV);
             } else {
-                addVecWithUV(verts[4], minU, minV);
-                addVecWithUV(verts[5], maxU, minV);
-                addVecWithUV(verts[6], maxU, maxV);
-                addVecWithUV(verts[7], minU, maxV);
+                cr.addVecWithUV(cr.verts[4], minU, minV);
+                cr.addVecWithUV(cr.verts[5], maxU, minV);
+                cr.addVecWithUV(cr.verts[6], maxU, maxV);
+                cr.addVecWithUV(cr.verts[7], minU, maxV);
             }
             if (dir == WEST || dir == EAST) {
                 float tmp = minU;
@@ -221,15 +218,15 @@ public class DefaultConduitRenderer implements ConduitRenderer {
                 tessellator.setColorOpaque_F(cm, cm, cm);
             }
             if (rotateTopBottom) {
-                addVecWithUV(verts[6], maxU, maxV);
-                addVecWithUV(verts[2], minU, maxV);
-                addVecWithUV(verts[3], minU, minV);
-                addVecWithUV(verts[7], maxU, minV);
+                cr.addVecWithUV(cr.verts[6], maxU, maxV);
+                cr.addVecWithUV(cr.verts[2], minU, maxV);
+                cr.addVecWithUV(cr.verts[3], minU, minV);
+                cr.addVecWithUV(cr.verts[7], maxU, minV);
             } else {
-                addVecWithUV(verts[6], minU, minV);
-                addVecWithUV(verts[2], minU, maxV);
-                addVecWithUV(verts[3], maxU, maxV);
-                addVecWithUV(verts[7], maxU, minV);
+                cr.addVecWithUV(cr.verts[6], minU, minV);
+                cr.addVecWithUV(cr.verts[2], minU, maxV);
+                cr.addVecWithUV(cr.verts[3], maxU, maxV);
+                cr.addVecWithUV(cr.verts[7], maxU, minV);
             }
 
             tessellator.setNormal(0, -1, 0);
@@ -238,15 +235,15 @@ public class DefaultConduitRenderer implements ConduitRenderer {
                 tessellator.setColorOpaque_F(cm, cm, cm);
             }
             if (rotateTopBottom) {
-                addVecWithUV(verts[0], minU, minV);
-                addVecWithUV(verts[1], minU, maxV);
-                addVecWithUV(verts[5], maxU, maxV);
-                addVecWithUV(verts[4], maxU, minV);
+                cr.addVecWithUV(cr.verts[0], minU, minV);
+                cr.addVecWithUV(cr.verts[1], minU, maxV);
+                cr.addVecWithUV(cr.verts[5], maxU, maxV);
+                cr.addVecWithUV(cr.verts[4], maxU, minV);
             } else {
-                addVecWithUV(verts[0], maxU, maxV);
-                addVecWithUV(verts[1], minU, maxV);
-                addVecWithUV(verts[5], minU, minV);
-                addVecWithUV(verts[4], maxU, minV);
+                cr.addVecWithUV(cr.verts[0], maxU, maxV);
+                cr.addVecWithUV(cr.verts[1], minU, maxV);
+                cr.addVecWithUV(cr.verts[5], minU, minV);
+                cr.addVecWithUV(cr.verts[4], maxU, minV);
             }
         }
 
@@ -258,15 +255,15 @@ public class DefaultConduitRenderer implements ConduitRenderer {
                 tessellator.setColorOpaque_F(cm, cm, cm);
             }
             if (rotateSides) {
-                addVecWithUV(verts[2], minU, maxV);
-                addVecWithUV(verts[6], minU, minV);
-                addVecWithUV(verts[5], maxU, minV);
-                addVecWithUV(verts[1], maxU, maxV);
+                cr.addVecWithUV(cr.verts[2], minU, maxV);
+                cr.addVecWithUV(cr.verts[6], minU, minV);
+                cr.addVecWithUV(cr.verts[5], maxU, minV);
+                cr.addVecWithUV(cr.verts[1], maxU, maxV);
             } else {
-                addVecWithUV(verts[2], minU, maxV);
-                addVecWithUV(verts[6], maxU, maxV);
-                addVecWithUV(verts[5], maxU, minV);
-                addVecWithUV(verts[1], minU, minV);
+                cr.addVecWithUV(cr.verts[2], minU, maxV);
+                cr.addVecWithUV(cr.verts[6], maxU, maxV);
+                cr.addVecWithUV(cr.verts[5], maxU, minV);
+                cr.addVecWithUV(cr.verts[1], minU, minV);
             }
 
             tessellator.setNormal(-1, 0, 0);
@@ -275,15 +272,15 @@ public class DefaultConduitRenderer implements ConduitRenderer {
                 tessellator.setColorOpaque_F(cm, cm, cm);
             }
             if (rotateSides) {
-                addVecWithUV(verts[0], maxU, maxV);
-                addVecWithUV(verts[4], maxU, minV);
-                addVecWithUV(verts[7], minU, minV);
-                addVecWithUV(verts[3], minU, maxV);
+                cr.addVecWithUV(cr.verts[0], maxU, maxV);
+                cr.addVecWithUV(cr.verts[4], maxU, minV);
+                cr.addVecWithUV(cr.verts[7], minU, minV);
+                cr.addVecWithUV(cr.verts[3], minU, maxV);
             } else {
-                addVecWithUV(verts[0], minU, minV);
-                addVecWithUV(verts[4], maxU, minV);
-                addVecWithUV(verts[7], maxU, maxV);
-                addVecWithUV(verts[3], minU, maxV);
+                cr.addVecWithUV(cr.verts[0], minU, minV);
+                cr.addVecWithUV(cr.verts[4], maxU, minV);
+                cr.addVecWithUV(cr.verts[7], maxU, maxV);
+                cr.addVecWithUV(cr.verts[3], minU, maxV);
             }
         }
         tessellator.setColorOpaque_F(1, 1, 1);
@@ -293,7 +290,7 @@ public class DefaultConduitRenderer implements ConduitRenderer {
         float xs = dir.offsetX == 0 ? transmissionScaleFactor : 1;
         float ys = dir.offsetY == 0 ? transmissionScaleFactor : 1;
         float zs = dir.offsetZ == 0 ? transmissionScaleFactor : 1;
-        setupVertices(bound.scale(xs, ys, zs));
+        CubeRenderer.get().setupVertices(bound.scale(xs, ys, zs));
     }
 
     // TODO: This is a really hacky, imprecise and slow way to do this

--- a/src/main/java/crazypants/enderio/conduit/render/ItemConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/ItemConduitRenderer.java
@@ -62,8 +62,9 @@ public class ItemConduitRenderer implements IItemRenderer {
     }
 
     private void renderToInventory(ItemStack item, RenderBlocks renderBlocks) {
-        Tessellator.instance.startDrawingQuads();
-        CubeRenderer.render(bb, item.getItem().getIconFromDamage(item.getItemDamage()));
-        Tessellator.instance.draw();
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
+        CubeRenderer.get().render(bb, item.getItem().getIconFromDamage(item.getItemDamage()));
+        tessellator.draw();
     }
 }

--- a/src/main/java/crazypants/enderio/enderface/EnderIoRenderer.java
+++ b/src/main/java/crazypants/enderio/enderface/EnderIoRenderer.java
@@ -55,7 +55,7 @@ public class EnderIoRenderer extends TileEntitySpecialRenderer implements IItemR
     }
 
     public void render(double x, double y, double z, Matrix4d lookMat, int brightness) {
-
+        final Tessellator tessellator = Tessellator.instance;
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
 
@@ -111,8 +111,8 @@ public class EnderIoRenderer extends TileEntitySpecialRenderer implements IItemR
         GL11.glTranslated(x, y, z);
 
         RenderUtil.bindBlockTexture();
-        Tessellator.instance.startDrawingQuads();
-        Tessellator.instance.setBrightness(brightness);
+        tessellator.startDrawingQuads();
+        tessellator.setBrightness(brightness);
 
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
@@ -120,8 +120,8 @@ public class EnderIoRenderer extends TileEntitySpecialRenderer implements IItemR
         GL11.glEnable(GL11.GL_POLYGON_OFFSET_FILL);
         GL11.glPolygonOffset(-1.0f, -1.0f);
 
-        CubeRenderer.render(BoundingBox.UNIT_CUBE, EnderIO.blockEnderIo.frameIcon);
-        Tessellator.instance.draw();
+        CubeRenderer.get().render(BoundingBox.UNIT_CUBE, EnderIO.blockEnderIo.frameIcon);
+        tessellator.draw();
         GL11.glPopMatrix();
 
         GL11.glDisable(GL11.GL_POLYGON_OFFSET_FILL);

--- a/src/main/java/crazypants/enderio/item/skull/EndermanSkullRenderer.java
+++ b/src/main/java/crazypants/enderio/item/skull/EndermanSkullRenderer.java
@@ -17,10 +17,12 @@ import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.RenderUtil;
 import com.enderio.core.client.render.VertexRotation;
 import com.enderio.core.common.vecmath.Vector3d;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.EnderIO;
 
+@ThreadSafeISBRH(perThread = false)
 public class EndermanSkullRenderer implements ISimpleBlockRenderingHandler, IItemRenderer {
 
     public EndermanSkullRenderer() {}
@@ -75,9 +77,9 @@ public class EndermanSkullRenderer implements ISimpleBlockRenderingHandler, IIte
         float height = 0.5f;
         BoundingBox bb = new BoundingBox(size, 0, size, 1 - size, height, 1 - size);
         if (renderer.hasOverrideBlockTexture()) {
-            CubeRenderer.render(bb, renderer.overrideBlockTexture, rot);
+            CubeRenderer.get().render(bb, renderer.overrideBlockTexture, rot);
         } else {
-            CubeRenderer.render(bb, icons, rot, true);
+            CubeRenderer.get().render(bb, icons, rot, true);
 
             if (meta > 1) {
                 renderBolts(rot, size);
@@ -94,27 +96,28 @@ public class EndermanSkullRenderer implements ISimpleBlockRenderingHandler, IIte
         float boltSize = size / 3;
         BoundingBox baseBolt = BoundingBox.UNIT_CUBE.scale(boltSize, boltSize, boltSize);
         IIcon icon = EnderIO.blockSoulFuser.getIcon(ForgeDirection.EAST.ordinal(), 0);
+        final CubeRenderer cr = CubeRenderer.get();
 
         float offset = 0.15f;
         bb = baseBolt.translate(size + boltSize / 2, -0.15f, offset);
-        CubeRenderer.render(bb, icon, rot, true);
+        cr.render(bb, icon, rot, true);
         bb = baseBolt.translate(size + boltSize / 2, -0.15f, -offset);
-        CubeRenderer.render(bb, icon, rot, true);
+        cr.render(bb, icon, rot, true);
 
         bb = baseBolt.translate(-(size + boltSize / 2), -0.15f, offset);
-        CubeRenderer.render(bb, icon, rot, true);
+        cr.render(bb, icon, rot, true);
         bb = baseBolt.translate(-(size + boltSize / 2), -0.15f, -offset);
-        CubeRenderer.render(bb, icon, rot, true);
+        cr.render(bb, icon, rot, true);
 
         bb = baseBolt.translate(-offset, -0.15f, -(size + boltSize / 2));
-        CubeRenderer.render(bb, icon, rot, true);
+        cr.render(bb, icon, rot, true);
         bb = baseBolt.translate(offset, -0.15f, -(size + boltSize / 2));
-        CubeRenderer.render(bb, icon, rot, true);
+        cr.render(bb, icon, rot, true);
 
         bb = baseBolt.translate(offset, -0.15f, (size + boltSize / 2));
-        CubeRenderer.render(bb, icon, rot, true);
+        cr.render(bb, icon, rot, true);
         bb = baseBolt.translate(-offset, -0.15f, (size + boltSize / 2));
-        CubeRenderer.render(bb, icon, rot, true);
+        cr.render(bb, icon, rot, true);
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/AbstractMachineRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineRenderer.java
@@ -19,12 +19,14 @@ import com.enderio.core.client.render.CustomRenderBlocks;
 import com.enderio.core.client.render.IconUtil;
 import com.enderio.core.client.render.RenderUtil;
 import com.enderio.core.common.vecmath.Vertex;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.machine.painter.IPaintableTileEntity;
 import crazypants.enderio.machine.painter.PaintedBlockRenderer;
 import crazypants.enderio.machine.painter.PainterUtil;
 
+@ThreadSafeISBRH(perThread = true)
 public class AbstractMachineRenderer implements ISimpleBlockRenderingHandler, IItemRenderer {
 
     private OverlayRenderer overlayRenderer = new OverlayRenderer() {
@@ -75,8 +77,9 @@ public class AbstractMachineRenderer implements ISimpleBlockRenderingHandler, II
 
         BoundingBox bb = BoundingBox.UNIT_CUBE;
         bb = bb.translate(0, -0.1f, 0);
+        final Tessellator tessellator = Tessellator.instance;
 
-        Tessellator.instance.startDrawingQuads();
+        tessellator.startDrawingQuads();
 
         IIcon[] textures = RenderUtil.getBlockTextures(block, metadata);
 
@@ -84,8 +87,8 @@ public class AbstractMachineRenderer implements ISimpleBlockRenderingHandler, II
         for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
             brightnessPerSide[dir.ordinal()] = Math.max(RenderUtil.getColorMultiplierForFace(dir) + 0.1f, 1f);
         }
-        CubeRenderer.render(bb, textures, null, brightnessPerSide);
-        Tessellator.instance.draw();
+        CubeRenderer.get().render(bb, textures, null, brightnessPerSide);
+        tessellator.draw();
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/OverlayRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/OverlayRenderer.java
@@ -19,7 +19,6 @@ import com.enderio.core.common.vecmath.Vertex;
 
 public class OverlayRenderer implements IRenderFace {
 
-    private static final CustomCubeRenderer ccr = CustomCubeRenderer.instance;
     private AbstractMachineEntity te;
 
     public void setTile(AbstractMachineEntity te) {
@@ -30,6 +29,7 @@ public class OverlayRenderer implements IRenderFace {
     @Override
     public void renderFace(CustomRenderBlocks rb, ForgeDirection face, Block par1Block, double x, double y, double z,
             IIcon texture, List<Vertex> refVertices, boolean translateToXyz) {
+        CustomCubeRenderer ccr = CustomCubeRenderer.get();
 
         if (te != null && par1Block instanceof AbstractMachineBlock) {
             BlockCoord bc = new BlockCoord(x, y, z);

--- a/src/main/java/crazypants/enderio/machine/capbank/render/CapBankRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/render/CapBankRenderer.java
@@ -21,6 +21,7 @@ import com.enderio.core.client.render.ConnectedTextureRenderer;
 import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.CustomCubeRenderer;
 import com.enderio.core.client.render.RenderUtil;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.relauncher.Side;
@@ -36,6 +37,7 @@ import crazypants.enderio.machine.capbank.render.FillGauge.GaugeKey;
 import crazypants.enderio.power.PowerHandlerUtil;
 
 @SideOnly(Side.CLIENT)
+@ThreadSafeISBRH(perThread = true)
 public class CapBankRenderer extends TileEntitySpecialRenderer implements ISimpleBlockRenderingHandler, IItemRenderer {
 
     private ConnectedTextureRenderer connectedTexRenderer;
@@ -47,7 +49,7 @@ public class CapBankRenderer extends TileEntitySpecialRenderer implements ISimpl
         connectedTexRenderer = new ConnectedTextureRenderer();
         connectedTexRenderer.setMatchMeta(true);
         fillGaugeRenderer = new FillGauge();
-        infoRenderers = new HashMap<InfoDisplayType, IInfoRenderer>();
+        infoRenderers = new HashMap<>();
         infoRenderers.put(InfoDisplayType.LEVEL_BAR, fillGaugeRenderer);
         infoRenderers.put(InfoDisplayType.IO, new IoDisplay());
     }
@@ -60,6 +62,7 @@ public class CapBankRenderer extends TileEntitySpecialRenderer implements ISimpl
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
             RenderBlocks renderer) {
+        CustomCubeRenderer ccr = CustomCubeRenderer.get();
 
         int meta = world.getBlockMetadata(x, y, z);
         meta = MathHelper.clamp_int(meta, 0, CapBankType.types().size() - 1);
@@ -70,13 +73,13 @@ public class CapBankRenderer extends TileEntitySpecialRenderer implements ISimpl
             connectedTexRenderer.setForceAllEdges(false);
         }
         connectedTexRenderer.setEdgeTexture(EnderIO.blockCapBank.getBorderIcon(0, meta));
-        CustomCubeRenderer.instance.setOverrideTexture(renderer.overrideBlockTexture);
+        ccr.setOverrideTexture(renderer.overrideBlockTexture);
         if (renderer.overrideBlockTexture == null) {
-            CustomCubeRenderer.instance.renderBlock(world, block, x, y, z, connectedTexRenderer);
+            ccr.renderBlock(world, block, x, y, z, connectedTexRenderer);
         } else {
-            CustomCubeRenderer.instance.renderBlock(world, block, x, y, z);
+            ccr.renderBlock(world, block, x, y, z);
         }
-        CustomCubeRenderer.instance.setOverrideTexture(null);
+        ccr.setOverrideTexture(null);
         return true;
     }
 
@@ -108,7 +111,7 @@ public class CapBankRenderer extends TileEntitySpecialRenderer implements ISimpl
         Tessellator tes = Tessellator.instance;
 
         tes.startDrawingQuads();
-        CubeRenderer.render(EnderIO.blockCapBank, item.getItemDamage());
+        CubeRenderer.get().render(EnderIO.blockCapBank, item.getItemDamage());
         tes.draw();
 
         GL11.glEnable(GL11.GL_POLYGON_OFFSET_FILL);

--- a/src/main/java/crazypants/enderio/machine/farm/FarmingStationRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/FarmingStationRenderer.java
@@ -28,13 +28,14 @@ public class FarmingStationRenderer extends TechneMachineRenderer<TileFarmStatio
         if (world != null) {
             TileEntity te = world.getTileEntity(x, y, z);
             if (te instanceof TileFarmStation && ((TileFarmStation) te).isActive()) {
+                final Tessellator tessellator = Tessellator.instance;
                 BoundingBox bb = BoundingBox.UNIT_CUBE.scale(10D / 16D, 0.25, 10D / 16D);
                 bb = bb.scale(1.01, 1, 1.01);
                 bb = bb.translate(0, 5f / 16f, 0);
                 bb = bb.translate(x, y, z);
-                Tessellator.instance.setColorOpaque_F(1, 1, 1);
-                Tessellator.instance.setBrightness(0xF000F0);
-                CubeRenderer.render(bb, override != null ? override : Blocks.portal.getBlockTextureFromSide(1));
+                tessellator.setColorOpaque_F(1, 1, 1);
+                tessellator.setBrightness(0xF000F0);
+                CubeRenderer.get().render(bb, override != null ? override : Blocks.portal.getBlockTextureFromSide(1));
             }
         }
 

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/ZombieGeneratorRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/ZombieGeneratorRenderer.java
@@ -89,7 +89,7 @@ public class ZombieGeneratorRenderer extends TileEntitySpecialRenderer implement
             }
             tes.setBrightness(brightness);
 
-            CubeRenderer.render(bb, icon);
+            CubeRenderer.get().render(bb, icon);
 
             GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
             GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/crazypants/enderio/machine/hypercube/HyperCubeRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/HyperCubeRenderer.java
@@ -111,7 +111,7 @@ public class HyperCubeRenderer extends TileEntitySpecialRenderer implements IIte
         } else {
             GL11.glColor4f(1, 1, 1, 1f);
         }
-        CubeRenderer.render(bb, icon);
+        CubeRenderer.get().render(bb, icon);
         tessellator.draw();
 
         GL11.glPopMatrix();

--- a/src/main/java/crazypants/enderio/machine/killera/KillerJoeRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/killera/KillerJoeRenderer.java
@@ -142,7 +142,7 @@ public class KillerJoeRenderer extends TileEntitySpecialRenderer implements IIte
             tes.setBrightness(brightness);
             tes.setColorOpaque_F(1, 1, 1);
 
-            CubeRenderer.render(bb, icon);
+            CubeRenderer.get().render(bb, icon);
 
             GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
             GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/crazypants/enderio/machine/light/ElectricLightRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/light/ElectricLightRenderer.java
@@ -9,9 +9,11 @@ import net.minecraft.world.IBlockAccess;
 import com.enderio.core.client.render.BoundingBox;
 import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.RenderUtil;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
+@ThreadSafeISBRH(perThread = false)
 public class ElectricLightRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
@@ -19,13 +21,13 @@ public class ElectricLightRenderer implements ISimpleBlockRenderingHandler {
 
         BoundingBox bb = new BoundingBox(0, 0, 0, 1, 0.2, 1);
         boolean doDraw = false;
-
-        Tessellator.instance.startDrawingQuads();
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
 
         IIcon[] textures = RenderUtil.getBlockTextures(block, metadata);
-        CubeRenderer.render(bb, textures, null, null);
+        CubeRenderer.get().render(bb, textures, null, null);
 
-        Tessellator.instance.draw();
+        tessellator.draw();
     }
 
     @Override
@@ -45,9 +47,9 @@ public class ElectricLightRenderer implements ISimpleBlockRenderingHandler {
 
         IIcon[] textures = RenderUtil.getBlockTextures(world, x, y, z);
         if (renderer.hasOverrideBlockTexture()) {
-            CubeRenderer.render(bb, renderer.overrideBlockTexture);
+            CubeRenderer.get().render(bb, renderer.overrideBlockTexture);
         } else {
-            CubeRenderer.render(bb, textures, null, null);
+            CubeRenderer.get().render(bb, textures, null, null);
         }
 
         return true;

--- a/src/main/java/crazypants/enderio/machine/obelisk/ObeliskRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/ObeliskRenderer.java
@@ -17,13 +17,15 @@ import com.enderio.core.client.render.RenderUtil;
 import com.enderio.core.common.vecmath.Vector3d;
 import com.enderio.core.common.vecmath.Vector3f;
 import com.enderio.core.common.vecmath.Vertex;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
+@ThreadSafeISBRH(perThread = true)
 public class ObeliskRenderer implements ISimpleBlockRenderingHandler {
 
-    private static final VertXForm2 xform2 = new VertXForm2();
-    private static final VertXForm3 xform3 = new VertXForm3();
+    private final VertXForm2 xform2 = new VertXForm2();
+    private final VertXForm3 xform3 = new VertXForm3();
 
     private static final float WIDE_PINCH = 0.9f;
     private static final float WIDTH = 18f / 32f * WIDE_PINCH;
@@ -39,11 +41,12 @@ public class ObeliskRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
+        final Tessellator tessellator = Tessellator.instance;
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_ALPHA_TEST);
-        Tessellator.instance.startDrawingQuads();
+        tessellator.startDrawingQuads();
         renderWorldBlock(null, 0, 0, 0, block, 0, renderer);
-        Tessellator.instance.draw();
+        tessellator.draw();
         GL11.glDisable(GL11.GL_ALPHA_TEST);
         GL11.glEnable(GL11.GL_LIGHTING);
     }
@@ -66,6 +69,8 @@ public class ObeliskRenderer implements ISimpleBlockRenderingHandler {
         } else { // item
             icons = RenderUtil.getBlockTextures(block, 0);
         }
+        final Tessellator tessellator = Tessellator.instance;
+        final CubeRenderer cr = CubeRenderer.get();
 
         // bottom texture goes into its own BB
         IIcon[] bottomIcons = new IIcon[6];
@@ -75,18 +80,18 @@ public class ObeliskRenderer implements ISimpleBlockRenderingHandler {
         bottomIcons[BOTTOM] = icons[BOTTOM];
         icons[BOTTOM] = IconUtil.blankTexture;
 
-        Tessellator.instance.addTranslation(x, y, z);
+        tessellator.addTranslation(x, y, z);
 
         xform2.isX = false;
-        CubeRenderer.render(bb1, icons, xform2, true);
+        cr.render(bb1, icons, xform2, true);
 
         xform2.isX = true;
         icons[TOP] = IconUtil.blankTexture;
-        CubeRenderer.render(bb2, icons, xform2, true);
+        cr.render(bb2, icons, xform2, true);
 
-        CubeRenderer.render(BoundingBox.UNIT_CUBE, bottomIcons, xform3, true);
+        cr.render(BoundingBox.UNIT_CUBE, bottomIcons, xform3, true);
 
-        Tessellator.instance.addTranslation(-x, -y, -z);
+        tessellator.addTranslation(-x, -y, -z);
 
         return true;
     }

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFenceGateRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFenceGateRenderer.java
@@ -7,9 +7,12 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.IBlockAccess;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.EnderIO;
 
+@ThreadSafeISBRH(perThread = false)
 public class BlockPaintedFenceGateRenderer implements ISimpleBlockRenderingHandler {
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/painter/PaintedBlockRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/painter/PaintedBlockRenderer.java
@@ -11,10 +11,13 @@ import net.minecraftforge.common.util.ForgeDirection;
 import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.IconUtil;
 import com.enderio.core.common.util.BlockCoord;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRHFactory;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.common.Optional;
 
-public class PaintedBlockRenderer implements ISimpleBlockRenderingHandler {
+@Optional.Interface(modid = "angelica", iface = "com.gtnewhorizons.angelica.api.ThreadSafeISBRHFactory")
+public class PaintedBlockRenderer implements ISimpleBlockRenderingHandler, ThreadSafeISBRHFactory {
 
     private int renderId;
     private Block defaultBlock;
@@ -22,6 +25,12 @@ public class PaintedBlockRenderer implements ISimpleBlockRenderingHandler {
     public PaintedBlockRenderer(int renderId, Block defaultBlock) {
         this.renderId = renderId;
         this.defaultBlock = defaultBlock;
+
+    }
+
+    @Override
+    public ThreadSafeISBRHFactory newInstance() {
+        return new PaintedBlockRenderer(renderId, defaultBlock);
     }
 
     @Override
@@ -31,9 +40,10 @@ public class PaintedBlockRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
     public void renderInventoryBlock(Block blk, int meta, int modelId, RenderBlocks arg3) {
-        Tessellator.instance.startDrawingQuads();
-        CubeRenderer.render(blk, meta);
-        Tessellator.instance.draw();
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
+        CubeRenderer.get().render(blk, meta);
+        tessellator.draw();
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/power/CapBankRenderer2.java
+++ b/src/main/java/crazypants/enderio/machine/power/CapBankRenderer2.java
@@ -24,18 +24,20 @@ import com.enderio.core.common.vecmath.Vector3d;
 import com.enderio.core.common.vecmath.Vector4d;
 import com.enderio.core.common.vecmath.Vector4f;
 import com.enderio.core.common.vecmath.Vertex;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.machine.power.GaugeBounds.VPos;
 
+@ThreadSafeISBRH(perThread = true)
 public class CapBankRenderer2 implements ISimpleBlockRenderingHandler {
 
     private static final BlockCoord DEFAULT_BC = new BlockCoord(0, 0, 0);
     private static final BlockCoord[] DEFAULT_MB = new BlockCoord[] { DEFAULT_BC };
     private static final double PIXEL_SIZE = 1 / 16d;
 
-    private final List<IRenderFace> renderers = new ArrayList<IRenderFace>(2);
+    private final List<IRenderFace> renderers = new ArrayList<>(2);
 
     private ConnectedTextureRenderer connectedTexRenderer;
 
@@ -67,7 +69,7 @@ public class CapBankRenderer2 implements ISimpleBlockRenderingHandler {
             connectedTexRenderer.setEdgeTexture(EnderIO.blockAlloySmelter.getBlockTextureFromSide(3));
             connectedTexRenderer.setForceAllEdges(false);
         }
-        CustomCubeRenderer.instance.renderBlock(world, block, x, y, z, renderers);
+        CustomCubeRenderer.get().renderBlock(world, block, x, y, z, renderers);
         return true;
     }
 

--- a/src/main/java/crazypants/enderio/machine/power/CapacitorBankRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/power/CapacitorBankRenderer.java
@@ -109,7 +109,8 @@ public class CapacitorBankRenderer extends TileEntitySpecialRenderer implements 
         }
 
         tes.startDrawingQuads();
-        CubeRenderer.render(BoundingBox.UNIT_CUBE, EnderIO.blockCapacitorBank.getIcon(0, 0), null, brightness, true);
+        CubeRenderer.get()
+                .render(BoundingBox.UNIT_CUBE, EnderIO.blockCapacitorBank.getIcon(0, 0), null, brightness, true);
         tes.draw();
 
         GL11.glEnable(GL11.GL_POLYGON_OFFSET_FILL);

--- a/src/main/java/crazypants/enderio/machine/ranged/RangeRenerer.java
+++ b/src/main/java/crazypants/enderio/machine/ranged/RangeRenerer.java
@@ -21,6 +21,7 @@ public class RangeRenerer extends RenderEntity {
     public void doRender(Entity entity, double x, double y, double z, float p_76986_8_, float p_76986_9_) {
 
         RangeEntity se = ((RangeEntity) entity);
+        final Tessellator tessellator = Tessellator.instance;
 
         GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
         GL11.glDisable(GL11.GL_LIGHTING);
@@ -43,10 +44,10 @@ public class RangeRenerer extends RenderEntity {
         GL11.glColor4f(1, 1, 1, 0.4f);
 
         RenderUtil.bindBlockTexture();
-        Tessellator.instance.startDrawingQuads();
-        Tessellator.instance.setBrightness(15 << 20 | 15 << 4);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE, IconUtil.whiteTexture);
-        Tessellator.instance.draw();
+        tessellator.startDrawingQuads();
+        tessellator.setBrightness(15 << 20 | 15 << 4);
+        CubeRenderer.get().render(BoundingBox.UNIT_CUBE, IconUtil.whiteTexture);
+        tessellator.draw();
 
         RenderUtil.bindItemTexture();
 

--- a/src/main/java/crazypants/enderio/machine/reservoir/ReservoirRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/reservoir/ReservoirRenderer.java
@@ -74,18 +74,19 @@ public class ReservoirRenderer extends TileEntitySpecialRenderer implements IRes
         GL11.glTranslatef((float) x + offset.x, (float) y + offset.y, (float) z + offset.z);
 
         BoundingBox bb = res.getLiquidRenderBounds();
+        final Tessellator tessellator = Tessellator.instance;
 
         if (res.isAutoEject()) {
 
             // switch
             RenderUtil.bindBlockTexture();
 
-            Tessellator.instance.startDrawingQuads();
-            Tessellator.instance.setColorRGBA_F(val, val, val, 1);
+            tessellator.startDrawingQuads();
+            tessellator.setColorRGBA_F(val, val, val, 1);
             for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
                 drawSwitch(dir, bb);
             }
-            Tessellator.instance.draw();
+            tessellator.draw();
         }
 
         if (fullness > 0) {
@@ -96,9 +97,9 @@ public class ReservoirRenderer extends TileEntitySpecialRenderer implements IRes
             IIcon tex = getLiquidTexture();
             float maxV = tex.getMinV() + ((tex.getMaxV() - tex.getMinV()) * fullness);
 
-            Tessellator.instance.startDrawingQuads();
-            Tessellator.instance.setColorRGBA_F(val, val, val, 1);
-            CubeRenderer.render(
+            tessellator.startDrawingQuads();
+            tessellator.setColorRGBA_F(val, val, val, 1);
+            CubeRenderer.get().render(
                     new BoundingBox(
                             bb.minX + margin,
                             bb.minY + margin,
@@ -110,7 +111,7 @@ public class ReservoirRenderer extends TileEntitySpecialRenderer implements IRes
                     tex.getMaxU(),
                     tex.getMinV(),
                     maxV);
-            Tessellator.instance.draw();
+            tessellator.draw();
         }
 
         GL11.glPopAttrib();
@@ -119,10 +120,10 @@ public class ReservoirRenderer extends TileEntitySpecialRenderer implements IRes
         Minecraft.getMinecraft().entityRenderer.enableLightmap(0);
     }
 
-    private Vector3d forward = new Vector3d();
-    private Vector3d left = new Vector3d();
-    private Vector3d up = new Vector3d();
-    private Vector3d offset = new Vector3d();
+    private final Vector3d forward = new Vector3d();
+    private final Vector3d left = new Vector3d();
+    private final Vector3d up = new Vector3d();
+    private final Vector3d offset = new Vector3d();
 
     private void drawSwitch(ForgeDirection dir, BoundingBox bb) {
         Tessellator tes = Tessellator.instance;

--- a/src/main/java/crazypants/enderio/machine/solar/SolarPanelRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/solar/SolarPanelRenderer.java
@@ -18,13 +18,15 @@ import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.CustomCubeRenderer;
 import com.enderio.core.client.render.IconUtil;
 import com.enderio.core.client.render.RenderUtil;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.EnderIO;
 
+@ThreadSafeISBRH(perThread = true)
 public class SolarPanelRenderer implements ISimpleBlockRenderingHandler {
 
-    private ConnectedTextureRenderer ctr;
+    private final ConnectedTextureRenderer ctr;
 
     public SolarPanelRenderer() {
         ctr = new ConnectedTextureRenderer();
@@ -40,7 +42,7 @@ public class SolarPanelRenderer implements ISimpleBlockRenderingHandler {
         float offset = -0.5f;
         tes.addTranslation(offset, 0, offset);
         tes.startDrawingQuads();
-        CubeRenderer.render(
+        CubeRenderer.get().render(
                 new BoundingBox(EnderIO.blockSolarPanel),
                 RenderUtil.getBlockTextures(EnderIO.blockSolarPanel, metadata),
                 false);
@@ -62,19 +64,23 @@ public class SolarPanelRenderer implements ISimpleBlockRenderingHandler {
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
             RenderBlocks renderer) {
+        CustomCubeRenderer ccr = CustomCubeRenderer.get();
+        final Tessellator tessellator = Tessellator.instance;
+
         renderer.renderStandardBlock(block, x, y, z);
-        Tessellator.instance.addTranslation(0, 0.0001f, 0);
+        tessellator.addTranslation(0, 0.0001f, 0);
         int meta = world.getBlockMetadata(x, y, z);
         meta = MathHelper.clamp_int(meta, 0, 1);
         ctr.setEdgeTexture(EnderIO.blockSolarPanel.getBorderIcon(0, meta));
-        CustomCubeRenderer.instance.setOverrideTexture(IconUtil.blankTexture);
+
+        ccr.setOverrideTexture(IconUtil.blankTexture);
         if (!renderer.hasOverrideBlockTexture()) {
-            CustomCubeRenderer.instance.renderBlock(world, block, x, y, z, ctr);
+            ccr.renderBlock(world, block, x, y, z, ctr);
         } else {
-            CustomCubeRenderer.instance.renderBlock(world, block, x, y, z);
+            ccr.renderBlock(world, block, x, y, z);
         }
-        CustomCubeRenderer.instance.setOverrideTexture(null);
-        Tessellator.instance.addTranslation(0, -0.0001f, 0);
+        ccr.setOverrideTexture(null);
+        tessellator.addTranslation(0, -0.0001f, 0);
         return true;
     }
 

--- a/src/main/java/crazypants/enderio/machine/soul/SoulBinderRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/soul/SoulBinderRenderer.java
@@ -14,11 +14,13 @@ import com.enderio.core.client.render.BoundingBox;
 import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.IconUtil;
 import com.enderio.core.common.util.ForgeDirectionOffsets;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.ClientProxy;
 import crazypants.enderio.EnderIO;
 
+@ThreadSafeISBRH(perThread = true)
 public class SoulBinderRenderer implements ISimpleBlockRenderingHandler {
 
     private float skullScale = 0.5f;
@@ -30,9 +32,10 @@ public class SoulBinderRenderer implements ISimpleBlockRenderingHandler {
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
 
         GL11.glDisable(GL11.GL_LIGHTING);
-        Tessellator.instance.startDrawingQuads();
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
         renderWorldBlock(null, 0, 0, 0, block, 0, renderer);
-        Tessellator.instance.draw();
+        tessellator.draw();
         GL11.glEnable(GL11.GL_LIGHTING);
     }
 
@@ -42,6 +45,8 @@ public class SoulBinderRenderer implements ISimpleBlockRenderingHandler {
 
         IIcon soulariumIcon = EnderIO.blockSoulFuser.getIcon(ForgeDirection.EAST.ordinal(), 0);
         override = renderer.overrideBlockTexture;
+        final Tessellator tessellator = Tessellator.instance;
+        final CubeRenderer cr = CubeRenderer.get();
 
         // Horrible hack to get the MC lighting engine to set the correct values for me
         if (renderer != null && world != null) {
@@ -51,23 +56,23 @@ public class SoulBinderRenderer implements ISimpleBlockRenderingHandler {
         }
         BoundingBox bb;
 
-        Tessellator.instance.addTranslation(x, y, z);
+        tessellator.addTranslation(x, y, z);
 
         bb = BoundingBox.UNIT_CUBE.scale(0.85, 0.85, 0.85);
         setIcons(soulariumIcon, soulariumIcon, ForgeDirection.NORTH);
-        CubeRenderer.render(bb, icons, true);
+        cr.render(bb, icons, true);
 
         float slabWidth = 0.15f;
         bb = BoundingBox.UNIT_CUBE.scale(1, slabWidth, 1);
         bb = bb.translate(0, 0.5f - (slabWidth / 2), 0);
         setIcons(soulariumIcon, EnderIO.blockSoulFuser.getIcon(ForgeDirection.UP.ordinal(), 0), ForgeDirection.UP);
-        CubeRenderer.render(bb, icons, true);
+        cr.render(bb, icons, true);
 
         bb = BoundingBox.UNIT_CUBE.scale(1, slabWidth, 1);
         bb = bb.translate(0, -0.5f + (slabWidth / 2), 0);
         setIcons(soulariumIcon, soulariumIcon, ForgeDirection.NORTH);
 
-        CubeRenderer.render(bb, icons, true);
+        cr.render(bb, icons, true);
 
         IIcon endermanIcon;
         int facing = ForgeDirection.SOUTH.ordinal();
@@ -86,7 +91,7 @@ public class SoulBinderRenderer implements ISimpleBlockRenderingHandler {
         renderSkull(forFacing(ForgeDirection.NORTH, facing), soulariumIcon, EnderIO.blockSoulFuser.zombieSkullIcon);
         renderSkull(forFacing(ForgeDirection.EAST, facing), soulariumIcon, EnderIO.blockSoulFuser.creeperSkullIcon);
 
-        Tessellator.instance.addTranslation(-x, -y, -z);
+        tessellator.addTranslation(-x, -y, -z);
 
         return true;
     }
@@ -99,7 +104,7 @@ public class SoulBinderRenderer implements ISimpleBlockRenderingHandler {
         BoundingBox bb;
         bb = scaledBB.translate(ForgeDirectionOffsets.offsetScaled(face, 0.5 - skullScale / 2));
         setIcons(soulariumIcon, faceIcon, face);
-        CubeRenderer.render(bb, icons, true);
+        CubeRenderer.get().render(bb, icons, true);
     }
 
     private void setIcons(IIcon defaultIcon, IIcon faceIcon, ForgeDirection faceSide) {

--- a/src/main/java/crazypants/enderio/machine/tank/TankFluidRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/tank/TankFluidRenderer.java
@@ -34,6 +34,7 @@ public class TankFluidRenderer extends TileEntitySpecialRenderer {
         }
         IIcon icon = tank.getFluid().getFluid().getStillIcon();
         if (icon != null) {
+            final Tessellator tessellator = Tessellator.instance;
             float fullness = tank.getFilledRatio();
             y += 0.01f; // prevent bottom side z-fighting
             float scale = 0.98f;
@@ -49,11 +50,11 @@ public class TankFluidRenderer extends TileEntitySpecialRenderer {
 
             RenderUtil.bindBlockTexture();
 
-            Tessellator.instance.startDrawingQuads();
-            Tessellator.instance.addTranslation(x, y, z);
-            CubeRenderer.render(bb, icon);
-            Tessellator.instance.addTranslation(-x, -y, -z);
-            Tessellator.instance.draw();
+            tessellator.startDrawingQuads();
+            tessellator.addTranslation(x, y, z);
+            CubeRenderer.get().render(bb, icon);
+            tessellator.addTranslation(-x, -y, -z);
+            tessellator.draw();
 
             GL11.glPopAttrib();
         }

--- a/src/main/java/crazypants/enderio/machine/tank/TankItemRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/tank/TankItemRenderer.java
@@ -42,11 +42,12 @@ public class TankItemRenderer implements IItemRenderer {
         GL11.glEnable(GL11.GL_ALPHA_TEST);
         Block block = EnderIO.blockTank;
         int meta = item.getItemDamage();
+        final Tessellator tessellator = Tessellator.instance;
 
         IIcon[] icons = RenderUtil.getBlockTextures(block, meta);
         BoundingBox bb = BoundingBox.UNIT_CUBE.translate(0, -0.1f, 0);
-        Tessellator.instance.startDrawingQuads();
-        CubeRenderer.render(bb, icons, null, RenderUtil.getDefaultPerSideBrightness());
-        Tessellator.instance.draw();
+        tessellator.startDrawingQuads();
+        CubeRenderer.get().render(bb, icons, null, RenderUtil.getDefaultPerSideBrightness());
+        tessellator.draw();
     }
 }

--- a/src/main/java/crazypants/enderio/machine/transceiver/render/TransceiverRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/render/TransceiverRenderer.java
@@ -162,7 +162,7 @@ public class TransceiverRenderer extends TileEntitySpecialRenderer implements II
         } else {
             GL11.glColor4f(1, 1, 1, 1f);
         }
-        CubeRenderer.render(bb, icon);
+        CubeRenderer.get().render(bb, icon);
         tessellator.draw();
 
         GL11.glPopMatrix();

--- a/src/main/java/crazypants/enderio/machine/vacuum/VacuumChestRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/vacuum/VacuumChestRenderer.java
@@ -11,18 +11,22 @@ import net.minecraftforge.client.IItemRenderer;
 
 import com.enderio.core.client.render.BoundingBox;
 import com.enderio.core.client.render.CubeRenderer;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.EnderIO;
 
+@ThreadSafeISBRH(perThread = false)
 public class VacuumChestRenderer implements ISimpleBlockRenderingHandler, IItemRenderer {
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
-        Tessellator.instance.startDrawingQuads();
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.6, 0.6, 0.6), EnderIO.blockHyperCube.getIcon(0, 0));
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.90, 0.90, 0.90), EnderIO.blockVacuumChest.getIcon(0, 0));
-        Tessellator.instance.draw();
+        final Tessellator tessellator = Tessellator.instance;
+        final CubeRenderer cr = CubeRenderer.get();
+        tessellator.startDrawingQuads();
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.6, 0.6, 0.6), EnderIO.blockHyperCube.getIcon(0, 0));
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.90, 0.90, 0.90), EnderIO.blockVacuumChest.getIcon(0, 0));
+        tessellator.draw();
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/wireless/WirelessChargerRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/wireless/WirelessChargerRenderer.java
@@ -13,10 +13,12 @@ import com.enderio.core.client.render.VertexRotation;
 import com.enderio.core.client.render.VertexTransformComposite;
 import com.enderio.core.client.render.VertexTranslation;
 import com.enderio.core.common.vecmath.Vector3d;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.EnderIO;
 
+@ThreadSafeISBRH(perThread = false)
 public class WirelessChargerRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
@@ -37,7 +39,8 @@ public class WirelessChargerRenderer implements ISimpleBlockRenderingHandler {
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
             RenderBlocks renderer) {
 
-        Tessellator tes = Tessellator.instance;
+        final Tessellator tes = Tessellator.instance;
+        final CubeRenderer cr = CubeRenderer.get();
 
         IIcon baseIcon = EnderIO.blockWirelessCharger.getIcon(0, 0);
 
@@ -50,34 +53,33 @@ public class WirelessChargerRenderer implements ISimpleBlockRenderingHandler {
         VertexTransform trans = new VertexTranslation(0, -0.5 + 0.025, 0);
 
         VertexTransformComposite xform = new VertexTransformComposite(rot, trans);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.7, 0.05, 0.7), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.7, 0.05, 0.7), baseIcon, xform, true);
 
         trans = new VertexTranslation(0, 0.5 - 0.025, 0);
         xform = new VertexTransformComposite(rot, trans);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.7, 0.05, 0.7), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.7, 0.05, 0.7), baseIcon, xform, true);
 
-        CubeRenderer
-                .render(BoundingBox.UNIT_CUBE.scale(0.2, 0.91, 0.2), EnderIO.blockWirelessCharger.getCenterOn(), true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.2, 0.91, 0.2), EnderIO.blockWirelessCharger.getCenterOn(), true);
 
         trans = new VertexTranslation(0, 0, 0.5 - 0.01);
         xform = new VertexTransformComposite(trans);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.25, 0.25, 0.01), baseIcon, xform, true);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.01, 1, 0.01), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.25, 0.25, 0.01), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.01, 1, 0.01), baseIcon, xform, true);
 
         rot = new VertexRotation(Math.toRadians(90), new Vector3d(0, 1, 0), new Vector3d(0.5, 0.5, 0.5));
         xform = new VertexTransformComposite(trans, rot);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.25, 0.25, 0.01), baseIcon, xform, true);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.01, 1, 0.01), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.25, 0.25, 0.01), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.01, 1, 0.01), baseIcon, xform, true);
 
         rot = new VertexRotation(Math.toRadians(180), new Vector3d(0, 1, 0), new Vector3d(0.5, 0.5, 0.5));
         xform = new VertexTransformComposite(trans, rot);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.25, 0.25, 0.01), baseIcon, xform, true);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.01, 1, 0.01), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.25, 0.25, 0.01), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.01, 1, 0.01), baseIcon, xform, true);
 
         rot = new VertexRotation(Math.toRadians(270), new Vector3d(0, 1, 0), new Vector3d(0.5, 0.5, 0.5));
         xform = new VertexTransformComposite(trans, rot);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.25, 0.25, 0.01), baseIcon, xform, true);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(0.01, 1, 0.01), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.25, 0.25, 0.01), baseIcon, xform, true);
+        cr.render(BoundingBox.UNIT_CUBE.scale(0.01, 1, 0.01), baseIcon, xform, true);
 
         tes.addTranslation(-x, -y, -z);
 

--- a/src/main/java/crazypants/enderio/material/FusedQuartzRenderer.java
+++ b/src/main/java/crazypants/enderio/material/FusedQuartzRenderer.java
@@ -14,6 +14,7 @@ import com.enderio.core.client.render.ConnectedTextureRenderer;
 import com.enderio.core.client.render.ConnectedTextureRenderer.DefaultTextureCallback;
 import com.enderio.core.client.render.CustomCubeRenderer;
 import com.enderio.core.client.render.RenderUtil;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import crazypants.enderio.EnderIO;
@@ -22,6 +23,7 @@ import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.painter.PainterUtil;
 import crazypants.enderio.machine.painter.TileEntityPaintedBlock;
 
+@ThreadSafeISBRH(perThread = false)
 public class FusedQuartzRenderer implements ISimpleBlockRenderingHandler {
 
     static int renderPass;
@@ -115,19 +117,19 @@ public class FusedQuartzRenderer implements ISimpleBlockRenderingHandler {
             return;
         }
 
-        CustomCubeRenderer.instance.setOverrideTexture(EnderIO.blockFusedQuartz.getIcon(0, meta));
+        final CustomCubeRenderer ccr = CustomCubeRenderer.get();
+
+        ccr.setOverrideTexture(EnderIO.blockFusedQuartz.getIcon(0, meta));
 
         if (tecb != null && tecb.getSourceBlock() != null) {
             connectedTextureRenderer.setEdgeTexureCallback(
                     new DefaultTextureCallback(tecb.getSourceBlock(), tecb.getSourceBlockMetadata()));
-            CustomCubeRenderer.instance
-                    .renderBlock(blockAccess, EnderIO.blockFusedQuartz, x, y, z, connectedTextureRenderer);
+            ccr.renderBlock(blockAccess, EnderIO.blockFusedQuartz, x, y, z, connectedTextureRenderer);
         } else {
             connectedTextureRenderer.setEdgeTexture(EnderIO.blockFusedQuartz.getDefaultFrameIcon(meta));
-            CustomCubeRenderer.instance
-                    .renderBlock(blockAccess, EnderIO.blockFusedQuartz, x, y, z, connectedTextureRenderer);
+            ccr.renderBlock(blockAccess, EnderIO.blockFusedQuartz, x, y, z, connectedTextureRenderer);
         }
 
-        CustomCubeRenderer.instance.setOverrideTexture(null);
+        ccr.setOverrideTexture(null);
     }
 }

--- a/src/main/java/crazypants/enderio/teleport/anchor/TravelEntitySpecialRenderer.java
+++ b/src/main/java/crazypants/enderio/teleport/anchor/TravelEntitySpecialRenderer.java
@@ -47,7 +47,6 @@ public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
 
     @Override
     public void renderTileEntityAt(TileEntity tileentity, double x, double y, double z, float f) {
-
         if (!TravelController.instance.showTargets()) {
             return;
         }
@@ -65,6 +64,8 @@ public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
         if (!ta.canSeeBlock(Minecraft.getMinecraft().thePlayer)) {
             return;
         }
+        final CubeRenderer cr = CubeRenderer.get();
+        final Tessellator tessellator = Tessellator.instance;
 
         Vector3d eye = Util.getEyePositionEio(Minecraft.getMinecraft().thePlayer);
         Vector3d loc = new Vector3d(tileentity.xCoord + 0.5, tileentity.yCoord + 0.5, tileentity.zCoord + 0.5);
@@ -102,20 +103,20 @@ public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
         GL11.glPushMatrix();
         GL11.glTranslated(x, y, z);
 
-        Tessellator.instance.startDrawingQuads();
+        tessellator.startDrawingQuads();
         renderBlock(tileentity.getWorldObj(), sf);
-        Tessellator.instance.draw();
+        tessellator.draw();
 
-        Tessellator.instance.startDrawingQuads();
-        Tessellator.instance.setBrightness(15 << 20 | 15 << 4);
+        tessellator.startDrawingQuads();
+        tessellator.setBrightness(15 << 20 | 15 << 4);
         if (TravelController.instance.isBlockSelected(bc)) {
-            Tessellator.instance.setColorRGBA_F(selectedColor.x, selectedColor.y, selectedColor.z, selectedColor.w);
-            CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(sf + 0.05, sf + 0.05, sf + 0.05), getSelectedIcon());
+            tessellator.setColorRGBA_F(selectedColor.x, selectedColor.y, selectedColor.z, selectedColor.w);
+            cr.render(BoundingBox.UNIT_CUBE.scale(sf + 0.05, sf + 0.05, sf + 0.05), getSelectedIcon());
         } else {
-            Tessellator.instance.setColorRGBA_F(highlightColor.x, highlightColor.y, highlightColor.z, highlightColor.w);
-            CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(sf + 0.05, sf + 0.05, sf + 0.05), getHighlightIcon());
+            tessellator.setColorRGBA_F(highlightColor.x, highlightColor.y, highlightColor.z, highlightColor.w);
+            cr.render(BoundingBox.UNIT_CUBE.scale(sf + 0.05, sf + 0.05, sf + 0.05), getHighlightIcon());
         }
-        Tessellator.instance.draw();
+        tessellator.draw();
         GL11.glPopMatrix();
 
         renderLabel(tileentity, x, y, z, ta, sf);
@@ -200,7 +201,7 @@ public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
 
     protected void renderBlock(IBlockAccess world, double sf) {
         Tessellator.instance.setColorRGBA_F(1, 1, 1, 0.75f);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(sf, sf, sf), EnderIO.blockTravelPlatform.getIcon(0, 0));
+        CubeRenderer.get().render(BoundingBox.UNIT_CUBE.scale(sf, sf, sf), EnderIO.blockTravelPlatform.getIcon(0, 0));
     }
 
     public Vector4f getSelectedColor() {

--- a/src/main/java/crazypants/enderio/teleport/telepad/TelePadRenderer.java
+++ b/src/main/java/crazypants/enderio/teleport/telepad/TelePadRenderer.java
@@ -92,8 +92,9 @@ public class TelePadRenderer extends TechneModelRenderer {
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
-        Tessellator.instance.startDrawingQuads();
-        CubeRenderer.render(block, metadata);
-        Tessellator.instance.draw();
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
+        CubeRenderer.get().render(block, metadata);
+        tessellator.draw();
     }
 }

--- a/src/main/java/crazypants/enderio/teleport/telepad/TelePadSpecialRenderer.java
+++ b/src/main/java/crazypants/enderio/teleport/telepad/TelePadSpecialRenderer.java
@@ -82,7 +82,7 @@ public class TelePadSpecialRenderer extends TravelEntitySpecialRenderer {
     @Override
     protected void renderBlock(IBlockAccess world, double sf) {
         Tessellator.instance.setColorRGBA_F(1, 1, 1, 0.75f);
-        CubeRenderer.render(BoundingBox.UNIT_CUBE.scale(sf, sf, sf), EnderIO.blockTelePad.getHighlightIcon());
+        CubeRenderer.get().render(BoundingBox.UNIT_CUBE.scale(sf, sf, sf), EnderIO.blockTelePad.getHighlightIcon());
     }
 
     @Override


### PR DESCRIPTION
Thread Saftey

* Depends on [EnderCore updates](https://github.com/GTNewHorizons/EnderCore/pull/19) for instanced CubeRenderer
* Switches relevant renderers to ThreadLocals, and adds a getRenderer() to Conduits
* Makes ConduitBundleRenderer threadsafe
* Misc reduction in allocations

Tested in the full pack :heavy_check_mark: 