### PR TITLE
Tweak teleport staff

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -174,6 +174,8 @@ public final class Config {
      * The distance travelled when no block is found within {@link #teleportStaffMaxBlinkDistance}.
      */
     public static int teleportStaffFailedBlinkDistance = 64;
+    /** If true, don't invert the staff of teleportation controls. */
+    public static boolean teleportStaffOriginalControls = false;
 
     public static int enderIoRange = 8;
     public static boolean enderIoMeAccessEnabled = true;
@@ -1268,6 +1270,14 @@ public final class Config {
                         teleportStaffFailedBlinkDistance,
                         "Number of blocks teleported when no block is being looked at.")
                 .getInt(teleportStaffFailedBlinkDistance);
+
+        teleportStaffOriginalControls = config
+                .get(
+                        sectionPersonal.name,
+                        "teleportStaffOriginalControls",
+                        teleportStaffOriginalControls,
+                        "If true, the staff of teleportation will use its original controls: R-Click for teleport to look, Shift R-Click for teleport to anchor.")
+                .getBoolean(teleportStaffOriginalControls);
 
         enderIoRange = config.get(
                 sectionEfficiency.name,

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -174,7 +174,7 @@ public final class Config {
      * The distance travelled when no block is found within {@link #teleportStaffMaxBlinkDistance}.
      */
     public static int teleportStaffFailedBlinkDistance = 64;
-    /** If true, don't invert the staff of teleportation controls. */
+    /** If true, use the original staff of teleportation controls. */
     public static boolean teleportStaffOriginalControls = false;
 
     public static int enderIoRange = 8;

--- a/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
@@ -2,6 +2,7 @@ package crazypants.enderio.teleport;
 
 import java.util.List;
 
+import crazypants.enderio.config.Config;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -56,10 +57,17 @@ public class ItemTeleportStaff extends ItemTravelStaff {
     @Override
     public ItemStack onItemRightClick(ItemStack equipped, World world, EntityPlayer player) {
         if (world.isRemote) {
-            if (player.isSneaking()) {
-                TravelController.instance
+            if (Config.teleportStaffOriginalControls) {
+                if (player.isSneaking()) {
+                    TravelController.instance
                         .activateTravelAccessable(equipped, world, player, TravelSource.TELEPORT_STAFF);
-            } else {
+                } else {
+                    TravelController.instance.doTeleport(player);
+                }
+            } else if (
+                    player.isSneaking()
+                        || !TravelController.instance
+                            .activateTravelAccessable(equipped, world, player, TravelSource.TELEPORT_STAFF)) {
                 TravelController.instance.doTeleport(player);
             }
         }

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -358,7 +358,7 @@ public class TravelController {
 
         double distanceIncrement = -2;
         // Special case: if the targeted block is too close, we'll try to teleport through it.
-        if (teleDistance < 3) {
+        if (teleDistance < 4) {
             distanceIncrement = 2;
         }
 
@@ -527,7 +527,7 @@ public class TravelController {
             }
             onBlockCoord = getActiveTravelBlock(player);
             boolean onBlock = onBlockCoord != null;
-            showTargets = onBlock || isTravelItemActive(player, false);
+            showTargets = onBlock || (isTravelItemActive(player, false) && !shouldHideTargets(player));
             if (showTargets) {
                 updateSelectedTarget(player);
             } else {
@@ -617,6 +617,11 @@ public class TravelController {
 
     public boolean isTravelItemActive(EntityPlayer ep, boolean checkInventoryAndBaubles) {
         return getTravelItemTravelSource(ep, checkInventoryAndBaubles) != null;
+    }
+
+    public boolean shouldHideTargets(EntityPlayer ep) {
+        return getTravelItemTravelSource(ep, false) != TravelSource.TELEPORT_STAFF
+            || (!Config.teleportStaffOriginalControls && ep.isSneaking());
     }
 
     /** Returns null if no travel item is in inventory/baubles. */

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -620,8 +620,8 @@ public class TravelController {
     }
 
     public boolean shouldHideTargets(EntityPlayer ep) {
-        return getTravelItemTravelSource(ep, false) != TravelSource.TELEPORT_STAFF
-            || (!Config.teleportStaffOriginalControls && ep.isSneaking());
+        return getTravelItemTravelSource(ep, false) == TravelSource.TELEPORT_STAFF
+            && !Config.teleportStaffOriginalControls && ep.isSneaking();
     }
 
     /** Returns null if no travel item is in inventory/baubles. */


### PR DESCRIPTION
New controls for the teleport staff: R-click will try to teleport to an anchor (the current shift-R-click behavior), and teleport to look (the current R-click behavior) if no anchor was found. Shift-R-click will teleport to look, ignoring anchors. Additionally, anchors will now be hidden while sneaking, so that they don't obstruct your view.

I don't know how people use the staff, so please do complain here if these changes would make it harder to use. There is also a config option to restore the original controls.

Also expand the teleport through wall range from 3 to 4, to help with being able to double-click on a distant wall to teleport to, then through it quickly.