### PR TITLE
Conduit Replacement Retains Connection Data

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
@@ -67,7 +67,6 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
         if (MicroblocksUtil.supportMicroblocks() && tryAddToMicroblocks(stack, player, world, x, y, z, side)) {
             return true;
         }
-
         BlockCoord placeAt = Util.canPlaceItem(stack, EnderIO.blockConduitBundle, player, world, x, y, z, side);
         if (placeAt != null) {
             if (!world.isRemote) {
@@ -84,9 +83,7 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
                 stack.stackSize--;
             }
             return true;
-
         } else {
-
             ForgeDirection dir = ForgeDirection.values()[side];
             int placeX = x + dir.offsetX;
             int placeY = y + dir.offsetY;
@@ -116,7 +113,6 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
                 }
             }
         }
-
         return false;
     }
 
@@ -162,8 +158,7 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
                     System.out.println("AbstractItemConduit.onItemUse: Conduit null.");
                     return false;
                 }
-                bundle.removeConduit(existingConduit);
-                bundle.addConduit(newConduit);
+                bundle.replaceConduit(existingConduit, newConduit);
                 if (!player.capabilities.isCreativeMode) {
                     stack.stackSize--;
                     for (ItemStack drop : existingConduit.getDrops()) {

--- a/src/main/java/crazypants/enderio/conduit/IConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/IConduitBundle.java
@@ -49,6 +49,8 @@ public interface IConduitBundle extends IInternalPowerHandler, IFluidHandler, II
 
     void addConduit(IConduit conduit);
 
+    void replaceConduit(IConduit original, IConduit replacement);
+
     void removeConduit(IConduit conduit);
 
     Collection<IConduit> getConduits();

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -409,12 +409,22 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
         if (worldObj.isRemote) {
             return;
         }
-
-        NBTTagCompound originalData = new NBTTagCompound();
-        original.writeToNBT(originalData);
+        // If you're wondering why I am not using conduit.writeToNBT, it is because there is some data that should not
+        // persist, some of which causes crashes with energy conduits.
+        NBTTagCompound[] originalData = new NBTTagCompound[ForgeDirection.values().length];
+        for (ForgeDirection conduitConnection : original.getConduitConnections()) {
+            NBTTagCompound tag = new NBTTagCompound();
+            original.writeConnectionSettingsToNBT(conduitConnection, tag);
+            originalData[conduitConnection.ordinal()] = tag;
+        }
         removeConduit(original);
         addConduit(replacement);
-        replacement.readFromNBT(originalData, originalData.getShort("nbtVersion"));
+        for (int i = 0; i < originalData.length; i++) {
+            NBTTagCompound nbt = originalData[i];
+            if (nbt != null) {
+                replacement.readConduitSettingsFromNBT(ForgeDirection.values()[i], nbt);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -412,7 +412,7 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
         // If you're wondering why I am not using conduit.writeToNBT, it is because there is some data that should not
         // persist, some of which causes crashes with energy conduits.
         NBTTagCompound[] originalData = new NBTTagCompound[ForgeDirection.values().length];
-        for (ForgeDirection conduitConnection : original.getConduitConnections()) {
+        for (ForgeDirection conduitConnection : original.getExternalConnections()) {
             NBTTagCompound tag = new NBTTagCompound();
             original.writeConnectionSettingsToNBT(conduitConnection, tag);
             originalData[conduitConnection.ordinal()] = tag;

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -405,6 +405,19 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
     }
 
     @Override
+    public void replaceConduit(IConduit original, IConduit replacement) {
+        if (worldObj.isRemote) {
+            return;
+        }
+
+        NBTTagCompound originalData = new NBTTagCompound();
+        original.writeToNBT(originalData);
+        removeConduit(original);
+        addConduit(replacement);
+        replacement.readFromNBT(originalData, originalData.getShort("nbtVersion"));
+    }
+
+    @Override
     public void removeConduit(IConduit conduit) {
         if (conduit != null) {
             removeConduit(conduit, true);


### PR DESCRIPTION
### Old Behavior
Replacing conduits erases connection data, meaning conduit networks need to be reconfigured. Especially inconvenient with fluid conduits.

### New Behavior
Replacing conduits retains connection data including I/O state, filters, channels, and RR state. Very easy to upgrade to more powerful fluid and energy conduits.