### PR TITLE
Add config entries for Farming Station particles

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -361,7 +361,8 @@ public final class Config {
             "TwilightForest:item.steeleafHoe", "TwilightForest:item.ironwoodHoe", "IC2:itemToolBronzeHoe" };
     public static List<ItemStack> farmHoes = new ArrayList<ItemStack>();
     public static int farmSaplingReserveAmount = 8;
-    public static double farmParticlesMaxRange = 20;
+    public static double farmParticlesMaxRange = 64;
+    public static int farmParticlesCount = 15;
 
     public static int magnetPowerUsePerSecondRF = 1;
     public static int magnetPowerCapacityRF = 100000;
@@ -2066,6 +2067,12 @@ public final class Config {
                 "farmParticlesMaxRange",
                 farmParticlesMaxRange,
                 "The max range of the farm action particles.").getDouble(farmParticlesMaxRange);
+
+        farmParticlesCount = config.get(
+                sectionFarm.name,
+                "farmParticlesCount",
+                farmParticlesCount,
+                "The number of particles produces by farm action.").getInt(farmParticlesCount);
 
         combustionGeneratorUseOpaqueModel = config
                 .get(

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -361,6 +361,7 @@ public final class Config {
             "TwilightForest:item.steeleafHoe", "TwilightForest:item.ironwoodHoe", "IC2:itemToolBronzeHoe" };
     public static List<ItemStack> farmHoes = new ArrayList<ItemStack>();
     public static int farmSaplingReserveAmount = 8;
+    public static double farmParticlesMaxRange = 20;
 
     public static int magnetPowerUsePerSecondRF = 1;
     public static int magnetPowerCapacityRF = 100000;
@@ -2059,6 +2060,12 @@ public final class Config {
                         + "saplings in store, it will only shear part the leaves and break the others for spalings. Set this to 0 to "
                         + "always shear all leaves.")
                 .getInt(farmSaplingReserveAmount);
+
+        farmParticlesMaxRange = config.get(
+                sectionFarm.name,
+                "farmParticlesMaxRange",
+                farmParticlesMaxRange,
+                "The max range of the farm action particles.").getDouble(farmParticlesMaxRange);
 
         combustionGeneratorUseOpaqueModel = config
                 .get(

--- a/src/main/java/crazypants/enderio/machine/farm/PacketFarmAction.java
+++ b/src/main/java/crazypants/enderio/machine/farm/PacketFarmAction.java
@@ -9,6 +9,7 @@ import com.enderio.core.common.util.BlockCoord;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import crazypants.enderio.config.Config;
 import crazypants.util.ClientUtil;
 import io.netty.buffer.ByteBuf;
 
@@ -51,7 +52,7 @@ public class PacketFarmAction implements IMessage, IMessageHandler<PacketFarmAct
 
     @Override
     public IMessage onMessage(PacketFarmAction message, MessageContext ctx) {
-        ClientUtil.spawnFarmParticles(rand, message.coords);
+        ClientUtil.spawnFarmParticles(rand, message.coords, Config.farmParticlesCount);
         return null;
     }
 }

--- a/src/main/java/crazypants/enderio/machine/farm/PacketFarmAction.java
+++ b/src/main/java/crazypants/enderio/machine/farm/PacketFarmAction.java
@@ -51,11 +51,7 @@ public class PacketFarmAction implements IMessage, IMessageHandler<PacketFarmAct
 
     @Override
     public IMessage onMessage(PacketFarmAction message, MessageContext ctx) {
-        for (BlockCoord bc : message.coords) {
-            for (int i = 0; i < 15; i++) {
-                ClientUtil.spawnFarmParcticles(rand, bc);
-            }
-        }
+        ClientUtil.spawnFarmParticles(rand, message.coords);
         return null;
     }
 }

--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -458,8 +458,9 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
             IHarvestResult harvest = FarmersCommune.instance.harvestBlock(this, bc, block, meta);
             if (harvest != null && harvest.getDrops() != null) {
                 PacketFarmAction pkt = new PacketFarmAction(harvest.getHarvestedBlocks());
-                PacketHandler.INSTANCE
-                        .sendToAllAround(pkt, new TargetPoint(worldObj.provider.dimensionId, bc.x, bc.y, bc.z, 64));
+                PacketHandler.INSTANCE.sendToAllAround(
+                        pkt,
+                        new TargetPoint(worldObj.provider.dimensionId, bc.x, bc.y, bc.z, Config.farmParticlesMaxRange));
                 for (EntityItem ei : harvest.getDrops()) {
                     if (ei != null) {
                         insertHarvestDrop(ei, bc);
@@ -487,7 +488,12 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
                     inventory[minFirtSlot] = farmerJoe.inventory.mainInventory[0];
                     PacketHandler.INSTANCE.sendToAllAround(
                             new PacketFarmAction(bc),
-                            new TargetPoint(worldObj.provider.dimensionId, bc.x, bc.y, bc.z, 64));
+                            new TargetPoint(
+                                    worldObj.provider.dimensionId,
+                                    bc.x,
+                                    bc.y,
+                                    bc.z,
+                                    Config.farmParticlesMaxRange));
                     if (inventory[minFirtSlot] != null && inventory[minFirtSlot].stackSize == 0) {
                         inventory[minFirtSlot] = null;
                     }

--- a/src/main/java/crazypants/util/ClientUtil.java
+++ b/src/main/java/crazypants/util/ClientUtil.java
@@ -1,10 +1,14 @@
 package crazypants.util;
 
+import java.util.List;
 import java.util.Random;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.particle.EffectRenderer;
+import net.minecraft.client.particle.EntityPortalFX;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
 
 import com.enderio.core.common.util.BlockCoord;
 
@@ -47,18 +51,34 @@ public class ClientUtil {
         con.readFromNBT(pkt.tc, TileConduitBundle.NBT_VERSION);
     }
 
-    public static void spawnFarmParcticles(Random rand, BlockCoord bc) {
-        double xOff = 0.5 + (rand.nextDouble() - 0.5) * 1.1;
-        double yOff = 0.5 + (rand.nextDouble() - 0.5) * 0.2;
-        double zOff = 0.5 + (rand.nextDouble() - 0.5) * 1.1;
-        Minecraft.getMinecraft().theWorld.spawnParticle(
-                "portal",
-                bc.x + xOff,
-                bc.y + yOff,
-                bc.z + zOff,
-                (rand.nextDouble() - 0.5) * 1.5,
-                -rand.nextDouble(),
-                (rand.nextDouble() - 0.5) * 1.5);
+    public static void spawnFarmParticles(Random rand, List<BlockCoord> coords) {
+        // 0 = All, 1 = Decreased, 2 = Minimal
+        int particleSetting = Minecraft.getMinecraft().gameSettings.particleSetting;
+        if (particleSetting >= 2 /* Minimal */) {
+            return;
+        }
+
+        int particles = particleSetting == 0 ? 6 /* All */ : 3 /* Decreased */;
+
+        World world = Minecraft.getMinecraft().theWorld;
+        EffectRenderer effectRenderer = Minecraft.getMinecraft().effectRenderer;
+
+        for (BlockCoord bc : coords) {
+            for (int i = 0; i < particles; i++) {
+                double xOff = 0.5 + (rand.nextDouble() - 0.5) * 1.1;
+                double yOff = 0.5 + (rand.nextDouble() - 0.5) * 0.2;
+                double zOff = 0.5 + (rand.nextDouble() - 0.5) * 1.1;
+                effectRenderer.addEffect(
+                        new EntityPortalFX(
+                                world,
+                                bc.x + xOff,
+                                bc.y + yOff,
+                                bc.z + zOff,
+                                (rand.nextDouble() - 0.5) * 1.5,
+                                -rand.nextDouble(),
+                                (rand.nextDouble() - 0.5) * 1.5));
+            }
+        }
     }
 
     public static void setTankNBT(PacketCombustionTank message, int x, int y, int z) {

--- a/src/main/java/crazypants/util/ClientUtil.java
+++ b/src/main/java/crazypants/util/ClientUtil.java
@@ -51,14 +51,15 @@ public class ClientUtil {
         con.readFromNBT(pkt.tc, TileConduitBundle.NBT_VERSION);
     }
 
-    public static void spawnFarmParticles(Random rand, List<BlockCoord> coords) {
+    public static void spawnFarmParticles(Random rand, List<BlockCoord> coords, int particlesCount) {
         // 0 = All, 1 = Decreased, 2 = Minimal
         int particleSetting = Minecraft.getMinecraft().gameSettings.particleSetting;
         if (particleSetting >= 2 /* Minimal */) {
             return;
         }
 
-        int particles = particleSetting == 0 ? 6 /* All */ : 3 /* Decreased */;
+        int particles = particleSetting == 0 ? particlesCount /* All */
+                : (particlesCount / 2) /* Decreased */;
 
         World world = Minecraft.getMinecraft().theWorld;
         EffectRenderer effectRenderer = Minecraft.getMinecraft().effectRenderer;


### PR DESCRIPTION
Nobody cares about these particles. But it can be pretty laggy with fast/large tree farms.

* decrease number of Farming Station particles (scaled with client setting)
* decrease range of Farming Station particles
* add max range of Farming Station particles to config