### PR TITLE
Travel Staff Blink Keybind fixes.

### DIFF
--- a/src/main/java/crazypants/enderio/item/KeyTracker.java
+++ b/src/main/java/crazypants/enderio/item/KeyTracker.java
@@ -154,7 +154,8 @@ public class KeyTracker {
                 if (player != null) {
                     ItemStack travelItem = player.getHeldItem();
                     if (travelItem == null || travelItem.getItem() == null
-                            || !(travelItem.getItem() instanceof IItemOfTravel)) {
+                            || !(travelItem.getItem() instanceof IItemOfTravel)
+                            || !((IItemOfTravel) travelItem.getItem()).isActive(player, travelItem)) {
                         travelItem = TravelController.instance.findTravelItemInInventoryOrBaubles(player);
                     }
 

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelSword.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelSword.java
@@ -386,7 +386,15 @@ public class ItemDarkSteelSword extends ItemSword
 
     @Override
     public boolean isActive(EntityPlayer ep, ItemStack equipped) {
-        return isTravelUpgradeActive(ep, equipped);
+        if (ep != null && equipped != null && isTravelUpgradeActive(ep, equipped)) {
+            // Only "active" if held while sneaking. But still "active" for the purposes of travel keybind if not held
+            if (isEquipped(ep)) {
+                return ep.isSneaking();
+            } else {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -400,12 +408,12 @@ public class ItemDarkSteelSword extends ItemSword
     }
 
     private boolean isTravelUpgradeActive(EntityPlayer ep, ItemStack equipped) {
-        return isEquipped(ep) && ep.isSneaking() && TravelUpgrade.loadFromItem(equipped) != null;
+        return ep != null && equipped != null && TravelUpgrade.loadFromItem(equipped) != null;
     }
 
     @Override
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
-        if (isTravelUpgradeActive(player, stack)) {
+        if (isActive(player, stack)) {
             if (world.isRemote) {
                 if (TravelController.instance.activateTravelAccessable(stack, world, player, TravelSource.STAFF)) {
                     player.swingItem();

--- a/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTeleportStaff.java
@@ -90,6 +90,12 @@ public class ItemTeleportStaff extends ItemTravelStaff {
     }
 
     @Override
+    public int getEnergyStored(ItemStack item) {
+        // Has infinite energy, always report as being full of energy for any validation-code purposes.
+        return this.capacity;
+    }
+
+    @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item item, CreativeTabs par2CreativeTabs, List par3List) {
         ItemStack is = new ItemStack(this);

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -160,7 +160,8 @@ public class TravelController {
             case STAFF_BLINK:
                 if (Config.travelStaffKeybindEnabled) {
                     if (equippedItem == null || equippedItem.getItem() == null
-                            || !(equippedItem.getItem() instanceof IItemOfTravel)) {
+                            || !(equippedItem.getItem() instanceof IItemOfTravel)
+                            || !((IItemOfTravel) equippedItem.getItem()).isActive(toTp, equippedItem)) {
                         equippedItem = findTravelItemInInventoryOrBaubles(toTp);
                     }
                 }
@@ -628,7 +629,8 @@ public class TravelController {
 
         ItemStack equipped = ep.getCurrentEquippedItem();
         if (checkInventoryAndBaubles) {
-            if (equipped == null || !(equipped.getItem() instanceof IItemOfTravel)) {
+            if (equipped == null || !(equipped.getItem() instanceof IItemOfTravel)
+                    || !((IItemOfTravel) equipped.getItem()).isActive(ep, equipped)) {
                 equipped = findTravelItemInInventoryOrBaubles(ep);
             }
         }
@@ -657,7 +659,8 @@ public class TravelController {
         ItemStack travelItem = null;
         for (int i = 0; i < ep.inventory.getSizeInventory(); i++) {
             ItemStack stack = ep.inventory.getStackInSlot(i);
-            if (stack != null && stack.getItem() instanceof IItemOfTravel) {
+            if (stack != null && stack.getItem() instanceof IItemOfTravel
+                    && ((IItemOfTravel) stack.getItem()).isActive(ep, stack)) {
                 travelItem = stack;
                 break;
             }
@@ -668,7 +671,8 @@ public class TravelController {
             if (baubles != null) {
                 for (int i = 0; i < baubles.getSizeInventory(); i++) {
                     ItemStack stack = baubles.getStackInSlot(i);
-                    if (stack != null && stack.getItem() instanceof IItemOfTravel) {
+                    if (stack != null && stack.getItem() instanceof IItemOfTravel
+                            && ((IItemOfTravel) stack.getItem()).isActive(ep, stack)) {
                         travelItem = stack;
                         break;
                     }
@@ -692,7 +696,8 @@ public class TravelController {
         int travelItemSlot = -1;
         for (int i = 0; i < ep.inventory.getSizeInventory(); i++) {
             ItemStack stack = ep.inventory.getStackInSlot(i);
-            if (stack != null && (stack.getItem() instanceof IItemOfTravel)) {
+            if (stack != null && stack.getItem() instanceof IItemOfTravel
+                    && ((IItemOfTravel) stack.getItem()).isActive(ep, stack)) {
                 travelItemSlot = i;
                 break;
             }
@@ -703,7 +708,8 @@ public class TravelController {
             if (baubles != null) {
                 for (int i = 0; i < baubles.getSizeInventory(); i++) {
                     ItemStack stack = baubles.getStackInSlot(i);
-                    if (stack != null && stack.getItem() instanceof IItemOfTravel) {
+                    if (stack != null && stack.getItem() instanceof IItemOfTravel
+                            && ((IItemOfTravel) stack.getItem()).isActive(ep, stack)) {
                         travelItemSlot = -(i + 2);
                         break;
                     }


### PR DESCRIPTION
Fixes 2 separate bugs with the SoT keybind.
1. Staff of Teleportation in GTNH pack specifically didn't work due to reporting as having 0 power through the RF API. 

    - Fixed this by having it always report that it's full of power since it has infinite/doesn't use power.

2. BlackSteelSword and EndSteelSword (The Ender and MKII) both were quite funky with keybind, causing no teleports to happen when they really should have. 
    - Fixed this through tweaks to how this is handled in a number of places to allow for proper handling while not changing the default held/shift held behavior.

Tested in SP, Anchor behavior while holding staffs and Swords with travel upgrade on them work as expected. Keybind now works and is able to use swords with travel upgrade on them. 
One quirk is that if you are holding a sword with travel upgrade, but NOT shifting, the sword itself stops counting as a valid travel item. So if ONLY using sword (no separate SoT in inventory), and holding the sword, the keybind will not work unless you hold shift. If you have another SoT in your inventory it will identify and use that and still blink you upon hitting keybind. This quirk doesn't really matter in most cases, just something worth noting.