### PR TITLE
Remove `isModLoaded` check for GTNH Lib

### DIFF
--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -46,7 +46,6 @@ import com.google.common.collect.Table;
 import com.google.common.collect.TreeBasedTable;
 import com.gtnewhorizon.gtnhlib.GTNHLib;
 
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ObfuscationReflectionHelper;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;

--- a/src/main/java/crazypants/enderio/teleport/TravelController.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelController.java
@@ -1188,19 +1188,15 @@ public class TravelController {
     }
 
     public static void showMessage(EntityPlayer player, IChatComponent chatComponent) {
-        if (Loader.isModLoaded("gtnhlib")) {
-            if (player instanceof EntityPlayerMP) {
-                chatComponent.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.WHITE));
-                GTNHLib.proxy.sendMessageAboveHotbar((EntityPlayerMP) player, chatComponent, 60, true, true);
-            } else {
-                GTNHLib.proxy.printMessageAboveHotbar(
-                        EnumChatFormatting.WHITE + chatComponent.getFormattedText(),
-                        60,
-                        true,
-                        true);
-            }
+        if (player instanceof EntityPlayerMP) {
+            chatComponent.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.WHITE));
+            GTNHLib.proxy.sendMessageAboveHotbar((EntityPlayerMP) player, chatComponent, 60, true, true);
         } else {
-            player.addChatComponentMessage(chatComponent);
+            GTNHLib.proxy.printMessageAboveHotbar(
+                    EnumChatFormatting.WHITE + chatComponent.getFormattedText(),
+                    60,
+                    true,
+                    true);
         }
     }
 }


### PR DESCRIPTION
Due to https://github.com/GTNewHorizons/EnderIO/pull/168, GTNH Lib is now a hard-dep. This makes the `Loader.isModLoaded()`-check obsolete.