### PR TITLE
fix broken oredicts for vibrantalloy and pulsatingIron

### DIFF
--- a/src/main/java/crazypants/enderio/material/Alloy.java
+++ b/src/main/java/crazypants/enderio/material/Alloy.java
@@ -33,9 +33,10 @@ public enum Alloy {
         if (oreDictName != null) {
             this.oreIngots.add("ingot" + StringUtils.capitalize(oreDictName));
             this.oreBlocks.add("block" + StringUtils.capitalize(oreDictName));
+        } else {
+            this.oreIngots.add("ingot" + StringUtils.capitalize(baseName));
+            this.oreBlocks.add("block" + StringUtils.capitalize(baseName));
         }
-        this.oreIngots.add("ingot" + StringUtils.capitalize(baseName));
-        this.oreBlocks.add("block" + StringUtils.capitalize(baseName));
         this.hardness = hardness;
     }
 


### PR DESCRIPTION
It was mistakenly adding two oredicts. upstream changed this 8 years ago in some refactors. This double oredict served no purpose and is causing severe compatability issues (e.g. with GT).

related to https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17538