### PR TITLE
No more TESR on conduits

### DIFF
--- a/src/main/java/crazypants/enderio/ClientProxy.java
+++ b/src/main/java/crazypants/enderio/ClientProxy.java
@@ -27,7 +27,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.conduit.BlockConduitBundle;
 import crazypants.enderio.conduit.IConduit;
-import crazypants.enderio.conduit.TileConduitBundle;
 import crazypants.enderio.conduit.facade.FacadeRenderer;
 import crazypants.enderio.conduit.gas.GasConduit;
 import crazypants.enderio.conduit.gas.GasUtil;
@@ -378,7 +377,6 @@ public class ClientProxy extends CommonProxy {
         cbr = new ConduitBundleRenderer((float) Config.conduitScale);
         BlockConduitBundle.rendererId = RenderingRegistry.getNextAvailableRenderId();
         RenderingRegistry.registerBlockHandler(cbr);
-        ClientRegistry.bindTileEntitySpecialRenderer(TileConduitBundle.class, cbr);
 
         ClientRegistry.bindTileEntitySpecialRenderer(TileTravelAnchor.class, new TravelEntitySpecialRenderer());
 

--- a/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
@@ -68,6 +68,7 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
         Tessellator tessellator = Tessellator.instance;
         if (isNSEWUD(component.dir)) {
             LiquidConduit lc = (LiquidConduit) conduit;
+            IIcon fluidTex = conduit.getTransmitionTextureForState(component);
             FluidStack fluid = lc.getFluidType();
             if (fluid != null) {
                 renderFluidOutline(component, fluid);
@@ -75,9 +76,7 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
             BoundingBox[] cubes = toCubes(component.bound);
             for (BoundingBox cube : cubes) {
                 drawSection(cube, tex.getMinU(), tex.getMaxU(), tex.getMinV(), tex.getMaxV(), component.dir, false);
-
-                tessellator.setColorOpaque_F(0.75f, 0.75f, 0.75f);
-                IIcon fluidTex = conduit.getTransmitionTextureForState(component);
+                tessellator.setColorOpaque_F(0.8f, 0.8f, 0.8f);
                 drawSection(
                     cube,
                     fluidTex.getMinU(),

--- a/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
@@ -1,7 +1,6 @@
 package crazypants.enderio.conduit.liquid;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -58,8 +57,7 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
     }
 
     public void renderDynamicEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit,
-                                    double x, double y, double z, float partialTick, float worldLight) {
-
+            double x, double y, double z, float partialTick, float worldLight) {
 
     }
 
@@ -76,23 +74,27 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
             BoundingBox[] cubes = toCubes(component.bound);
             for (BoundingBox cube : cubes) {
                 drawSection(cube, tex.getMinU(), tex.getMaxU(), tex.getMinV(), tex.getMaxV(), component.dir, false);
-                tessellator.setColorOpaque_F(0.8f, 0.8f, 0.8f);
+                tessellator.setColorOpaque_F(0.7f, 0.7f, 0.7f);
                 drawSection(
-                    cube,
-                    fluidTex.getMinU(),
-                    fluidTex.getMaxU(),
-                    fluidTex.getMinV(),
-                    fluidTex.getMaxV(),
-                    component.dir,
-                    true);
+                        cube,
+                        fluidTex.getMinU(),
+                        fluidTex.getMaxU(),
+                        fluidTex.getMinV(),
+                        fluidTex.getMaxV(),
+                        component.dir,
+                        true);
             }
 
             if (conduit.getConnectionMode(component.dir) == ConnectionMode.DISABLED) {
                 final CubeRenderer cr = CubeRenderer.get();
                 int i;
                 tex = EnderIO.blockConduitBundle.getConnectorIcon(component.data);
-                List<Vertex> corners = component.bound
-                    .getCornersWithUvForFace(component.dir, tex.getMinU(), tex.getMaxU(), tex.getMinV(), tex.getMaxV());
+                List<Vertex> corners = component.bound.getCornersWithUvForFace(
+                        component.dir,
+                        tex.getMinU(),
+                        tex.getMaxU(),
+                        tex.getMinV(),
+                        tex.getMaxV());
                 for (i = corners.size() - 1; i >= 0; i--) {
                     Vertex c = corners.get(i);
                     cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);

--- a/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
@@ -57,6 +57,12 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
         super.renderEntity(conduitBundleRenderer, te, conduit, x, y, z, partialTick, worldLight, rb);
     }
 
+    public void renderDynamicEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit,
+                                    double x, double y, double z, float partialTick, float worldLight) {
+
+
+    }
+
     @Override
     protected void renderConduit(IIcon tex, IConduit conduit, CollidableComponent component, float brightness) {
         if (isNSEWUD(component.dir)) {
@@ -69,7 +75,6 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
             for (BoundingBox cube : cubes) {
                 drawSection(cube, tex.getMinU(), tex.getMaxU(), tex.getMinV(), tex.getMaxV(), component.dir, false);
             }
-
         } else {
             drawSection(
                     component.bound,
@@ -95,6 +100,38 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
             for (i = corners.size() - 1; i >= 0; i--) {
                 Vertex c = corners.get(i);
                 cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+            }
+        }
+
+        if (((LiquidConduit) conduit).getTank().getFilledRatio() <= 0) {
+            return;
+        }
+
+        Collection<CollidableComponent> components = conduit.getCollidableComponents();
+        Tessellator tessellator = Tessellator.instance;
+
+        calculateRatios((LiquidConduit) conduit);
+        transmissionScaleFactor = conduit.getTransmitionGeometryScale();
+
+        for (CollidableComponent othercomponent : components) {
+            if (renderComponent(othercomponent)) {
+                if (isNSEWUD(othercomponent.dir) && conduit.getTransmitionTextureForState(othercomponent) != null) {
+
+                    tessellator.setColorOpaque_F(1, 1, 1);
+                    tex = conduit.getTransmitionTextureForState(othercomponent);
+
+                    BoundingBox[] cubes = toCubes(othercomponent.bound);
+                    for (BoundingBox cube : cubes) {
+                        drawSection(
+                            cube,
+                            tex.getMinU(),
+                            tex.getMaxU(),
+                            tex.getMinV(),
+                            tex.getMaxV(),
+                            othercomponent.dir,
+                            true);
+                    }
+                }
             }
         }
     }
@@ -241,49 +278,6 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
     @Override
     protected void renderTransmission(IConduit con, IIcon tex, CollidableComponent component, float brightness) {
         // done in the dynamic section
-    }
-
-    @Override
-    public boolean isDynamic() {
-        return true;
-    }
-
-    @Override
-    public void renderDynamicEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit conduit,
-            double x, double y, double z, float partialTick, float worldLight) {
-
-        if (((LiquidConduit) conduit).getTank().getFilledRatio() <= 0) {
-            return;
-        }
-
-        Collection<CollidableComponent> components = conduit.getCollidableComponents();
-        Tessellator tessellator = Tessellator.instance;
-
-        calculateRatios((LiquidConduit) conduit);
-        transmissionScaleFactor = conduit.getTransmitionGeometryScale();
-
-        IIcon tex;
-        for (CollidableComponent component : components) {
-            if (renderComponent(component)) {
-                if (isNSEWUD(component.dir) && conduit.getTransmitionTextureForState(component) != null) {
-
-                    tessellator.setColorOpaque_F(1, 1, 1);
-                    tex = conduit.getTransmitionTextureForState(component);
-
-                    BoundingBox[] cubes = toCubes(component.bound);
-                    for (BoundingBox cube : cubes) {
-                        drawSection(
-                                cube,
-                                tex.getMinU(),
-                                tex.getMaxU(),
-                                tex.getMinV(),
-                                tex.getMaxV(),
-                                component.dir,
-                                true);
-                    }
-                }
-            }
-        }
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
@@ -74,6 +74,10 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
             BoundingBox[] cubes = toCubes(component.bound);
             for (BoundingBox cube : cubes) {
                 drawSection(cube, tex.getMinU(), tex.getMaxU(), tex.getMinV(), tex.getMaxV(), component.dir, false);
+                // This check is kinda broken, but whatever, it was like that when this was done in a TESR too
+                if (lc.getTank().getFilledRatio() <= 0) {
+                    continue;
+                }
                 tessellator.setColorOpaque_F(0.7f, 0.7f, 0.7f);
                 drawSection(
                         cube,

--- a/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduitRenderer.java
@@ -65,6 +65,7 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
 
     @Override
     protected void renderConduit(IIcon tex, IConduit conduit, CollidableComponent component, float brightness) {
+        Tessellator tessellator = Tessellator.instance;
         if (isNSEWUD(component.dir)) {
             LiquidConduit lc = (LiquidConduit) conduit;
             FluidStack fluid = lc.getFluidType();
@@ -74,63 +75,33 @@ public class LiquidConduitRenderer extends DefaultConduitRenderer implements IRe
             BoundingBox[] cubes = toCubes(component.bound);
             for (BoundingBox cube : cubes) {
                 drawSection(cube, tex.getMinU(), tex.getMaxU(), tex.getMinV(), tex.getMaxV(), component.dir, false);
-            }
-        } else {
-            drawSection(
-                    component.bound,
-                    tex.getMinU(),
-                    tex.getMaxU(),
-                    tex.getMinV(),
-                    tex.getMaxV(),
+
+                tessellator.setColorOpaque_F(0.75f, 0.75f, 0.75f);
+                IIcon fluidTex = conduit.getTransmitionTextureForState(component);
+                drawSection(
+                    cube,
+                    fluidTex.getMinU(),
+                    fluidTex.getMaxU(),
+                    fluidTex.getMinV(),
+                    fluidTex.getMaxV(),
                     component.dir,
                     true);
-        }
+            }
 
-        if (conduit.getConnectionMode(component.dir) == ConnectionMode.DISABLED) {
-            final CubeRenderer cr = CubeRenderer.get();
-            int i;
-            tex = EnderIO.blockConduitBundle.getConnectorIcon(component.data);
-            List<Vertex> corners = component.bound
+            if (conduit.getConnectionMode(component.dir) == ConnectionMode.DISABLED) {
+                final CubeRenderer cr = CubeRenderer.get();
+                int i;
+                tex = EnderIO.blockConduitBundle.getConnectorIcon(component.data);
+                List<Vertex> corners = component.bound
                     .getCornersWithUvForFace(component.dir, tex.getMinU(), tex.getMaxU(), tex.getMinV(), tex.getMaxV());
-            for (i = corners.size() - 1; i >= 0; i--) {
-                Vertex c = corners.get(i);
-                cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
-            }
-            // back face
-            for (i = corners.size() - 1; i >= 0; i--) {
-                Vertex c = corners.get(i);
-                cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
-            }
-        }
-
-        if (((LiquidConduit) conduit).getTank().getFilledRatio() <= 0) {
-            return;
-        }
-
-        Collection<CollidableComponent> components = conduit.getCollidableComponents();
-        Tessellator tessellator = Tessellator.instance;
-
-        calculateRatios((LiquidConduit) conduit);
-        transmissionScaleFactor = conduit.getTransmitionGeometryScale();
-
-        for (CollidableComponent othercomponent : components) {
-            if (renderComponent(othercomponent)) {
-                if (isNSEWUD(othercomponent.dir) && conduit.getTransmitionTextureForState(othercomponent) != null) {
-
-                    tessellator.setColorOpaque_F(1, 1, 1);
-                    tex = conduit.getTransmitionTextureForState(othercomponent);
-
-                    BoundingBox[] cubes = toCubes(othercomponent.bound);
-                    for (BoundingBox cube : cubes) {
-                        drawSection(
-                            cube,
-                            tex.getMinU(),
-                            tex.getMaxU(),
-                            tex.getMinV(),
-                            tex.getMaxV(),
-                            othercomponent.dir,
-                            true);
-                    }
+                for (i = corners.size() - 1; i >= 0; i--) {
+                    Vertex c = corners.get(i);
+                    cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
+                }
+                // back face
+                for (i = corners.size() - 1; i >= 0; i--) {
+                    Vertex c = corners.get(i);
+                    cr.addVecWithUV(c.xyz, c.uv.x, c.uv.y);
                 }
             }
         }

--- a/src/main/java/crazypants/enderio/conduit/render/ConduitBundleRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/ConduitBundleRenderer.java
@@ -11,7 +11,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
@@ -19,13 +18,9 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
-
 import com.enderio.core.client.render.BoundingBox;
 import com.enderio.core.client.render.CubeRenderer;
 import com.enderio.core.client.render.IconUtil;
-import com.enderio.core.client.render.RenderUtil;
 import com.enderio.core.common.util.BlockCoord;
 import com.enderio.core.common.util.IBlockAccessWrapper;
 import com.google.common.collect.Lists;
@@ -53,58 +48,11 @@ import crazypants.util.RenderPassHelper;
 
 @SideOnly(Side.CLIENT)
 @ThreadSafeISBRH(perThread = false)
-public class ConduitBundleRenderer extends TileEntitySpecialRenderer implements ISimpleBlockRenderingHandler {
+public class ConduitBundleRenderer implements ISimpleBlockRenderingHandler {
 
     public ConduitBundleRenderer(float conduitScale) {}
 
     public ConduitBundleRenderer() {}
-
-    @Override
-    public void renderTileEntityAt(TileEntity te, double x, double y, double z, float partialTick) {
-        IConduitBundle bundle = (IConduitBundle) te;
-        EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
-        if (bundle == null || (bundle.hasFacade() && bundle.getFacadeId().isOpaqueCube()
-                && !ConduitUtil.isFacadeHidden(bundle, player))) {
-            return;
-        }
-        final Tessellator tessellator = Tessellator.instance;
-
-        float brightness = -1;
-        for (IConduit con : bundle.getConduits()) {
-            if (ConduitUtil.renderConduit(player, con)) {
-                final ConduitRenderer renderer = con.getRenderer();
-                if (renderer.isDynamic()) {
-                    if (brightness == -1) {
-                        BlockCoord loc = bundle.getLocation();
-                        brightness = bundle.getEntity().getWorldObj()
-                                .getLightBrightnessForSkyBlocks(loc.x, loc.y, loc.z, 0);
-
-                        RenderUtil.bindBlockTexture();
-
-                        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_LIGHTING_BIT);
-                        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
-                        GL11.glEnable(GL11.GL_BLEND);
-                        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                        GL11.glShadeModel(GL11.GL_SMOOTH);
-
-                        GL11.glPushMatrix();
-                        GL11.glTranslated(x, y, z);
-
-                        tessellator.startDrawingQuads();
-                    }
-                    renderer.renderDynamicEntity(this, bundle, con, x, y, z, partialTick, brightness);
-                }
-            }
-        }
-
-        if (brightness != -1) {
-            tessellator.draw();
-
-            GL11.glShadeModel(GL11.GL_FLAT);
-            GL11.glPopMatrix();
-            GL11.glPopAttrib();
-        }
-    }
 
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,

--- a/src/main/java/crazypants/enderio/conduit/render/ConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/ConduitRenderer.java
@@ -10,8 +10,4 @@ public interface ConduitRenderer {
     void renderEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit con, double x, double y,
             double z, float partialTick, float worldLight, RenderBlocks rb);
 
-    boolean isDynamic();
-
-    void renderDynamicEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit con, double x,
-            double y, double z, float partialTick, float worldLight);
 }

--- a/src/main/java/crazypants/enderio/conduit/render/DefaultConduitRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/DefaultConduitRenderer.java
@@ -63,10 +63,6 @@ public class DefaultConduitRenderer implements ConduitRenderer {
         }
     }
 
-    @Override
-    public void renderDynamicEntity(ConduitBundleRenderer conduitBundleRenderer, IConduitBundle te, IConduit con,
-            double x, double y, double z, float partialTick, float worldLight) {}
-
     protected void renderConduit(IIcon tex, IConduit conduit, CollidableComponent component, float brightness) {
         final CubeRenderer cr = CubeRenderer.get();
 
@@ -349,8 +345,4 @@ public class DefaultConduitRenderer implements ConduitRenderer {
         return new BoundingBox[] { bb };
     }
 
-    @Override
-    public boolean isDynamic() {
-        return false;
-    }
 }


### PR DESCRIPTION
This change completely removes the TESR for all conduits. The TESR was only actually used by the basic fluid conduit to render the fluid texture inside the conduit, this is mostly entirely unnecessary and can be rendered via the ISBRH.

All conduits other than the basic fluid conduit are completely unchanged by this, and as of writing there is a minor change to the rendering of the basic fluid conduit. The first image below is the original rendering with the TESR, the second image is the new rendering from ISBRH. The only different is that I'm not sure how to make it not darken the top(I also can't tell how the TESR is doing this either).

![image](https://github.com/user-attachments/assets/334185cb-6e0e-4ab2-bf64-84f5d53a0bbf)
![image](https://github.com/user-attachments/assets/0ffe7e3c-e30e-43f0-808c-eddb7ff3f81d)

The advantage of this change is that currently the TESR, while largely unused, is still implemented for every single conduit, meaning that the rendering loop for TESRs has to waste time going through each conduit, even if it's ultimately just going to do some checks and then not render anything.
