### PR TITLE
Fix naturalist's eyes

### DIFF
--- a/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelArmor.java
@@ -322,7 +322,7 @@ public class ItemDarkSteelArmor extends ItemArmor
     @Override
     @Method(modid = "Forestry")
     public boolean canSeePollination(EntityPlayer player, ItemStack armor, boolean doSee) {
-        if (armor == null || DarkSteelItems.isArmorPart(armor.getItem(), 0)) {
+        if (armor == null || !DarkSteelItems.isArmorPart(armor.getItem(), 0)) {
             return false;
         }
         return NaturalistEyeUpgrade.isUpgradeEquipped(player);


### PR DESCRIPTION
The naturalist's eyes upgrade for the dark helm had a flipped bool condition and didn't work.

Fixed it