### PR TITLE
Change hazmat Optional decorators' modid from `gregtech` to `gregtech_nh` to add gt6 compat

### DIFF
--- a/src/main/java/crazypants/enderio/EnderIO.java
+++ b/src/main/java/crazypants/enderio/EnderIO.java
@@ -208,7 +208,7 @@ public class EnderIO {
     public static final Lang lang = new Lang("enderio");
 
     public static final boolean hasLwjgl3 = Loader.isModLoaded("lwjgl3ify");
-    public static final boolean hasGT5 = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi_post");
+    public static final boolean hasGT5 = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
 
     // Materials
     public static ItemCapacitor itemBasicCapacitor;

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
@@ -17,7 +17,7 @@ import crazypants.enderio.item.darksteel.upgrade.IDarkSteelUpgrade;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.hazards.IHazardProtector;
 
-@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft") })
+@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH") })
 public class ItemEndSteelArmor extends ItemDarkSteelArmor implements IEndSteelItem, IHazardProtector {
 
     public static final ArmorMaterial MATERIAL = EnumHelper
@@ -83,7 +83,7 @@ public class ItemEndSteelArmor extends ItemDarkSteelArmor implements IEndSteelIt
     }
 
     /// GT5 Hazmat protection
-    @Optional.Method(modid = "dreamcraft")
+    @Optional.Method(modid = "gregtechNH")
     @Override
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return true;

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
@@ -17,7 +17,7 @@ import crazypants.enderio.item.darksteel.upgrade.IDarkSteelUpgrade;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.hazards.IHazardProtector;
 
-@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH") })
+@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech_nh") })
 public class ItemEndSteelArmor extends ItemDarkSteelArmor implements IEndSteelItem, IHazardProtector {
 
     public static final ArmorMaterial MATERIAL = EnumHelper
@@ -83,7 +83,7 @@ public class ItemEndSteelArmor extends ItemDarkSteelArmor implements IEndSteelIt
     }
 
     /// GT5 Hazmat protection
-    @Optional.Method(modid = "gregtechNH")
+    @Optional.Method(modid = "gregtech_nh")
     @Override
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return true;

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
@@ -17,7 +17,7 @@ import crazypants.enderio.item.darksteel.upgrade.IDarkSteelUpgrade;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.hazards.IHazardProtector;
 
-@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech") })
+@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft") })
 public class ItemEndSteelArmor extends ItemDarkSteelArmor implements IEndSteelItem, IHazardProtector {
 
     public static final ArmorMaterial MATERIAL = EnumHelper
@@ -83,7 +83,7 @@ public class ItemEndSteelArmor extends ItemDarkSteelArmor implements IEndSteelIt
     }
 
     /// GT5 Hazmat protection
-    @Optional.Method(modid = "gregtech")
+    @Optional.Method(modid = "dreamcraft")
     @Override
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return true;

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemStellarArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemStellarArmor.java
@@ -17,7 +17,7 @@ import crazypants.enderio.item.darksteel.upgrade.IDarkSteelUpgrade;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.hazards.IHazardProtector;
 
-@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech") })
+@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft") })
 public class ItemStellarArmor extends ItemDarkSteelArmor implements IStellarItem, IHazardProtector {
 
     public static final ArmorMaterial MATERIAL = EnumHelper
@@ -84,7 +84,7 @@ public class ItemStellarArmor extends ItemDarkSteelArmor implements IStellarItem
     }
 
     /// GT5 Hazmat protection
-    @Optional.Method(modid = "gregtech")
+    @Optional.Method(modid = "dreamcraft")
     @Override
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return true;

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemStellarArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemStellarArmor.java
@@ -17,7 +17,7 @@ import crazypants.enderio.item.darksteel.upgrade.IDarkSteelUpgrade;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.hazards.IHazardProtector;
 
-@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH") })
+@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech_nh") })
 public class ItemStellarArmor extends ItemDarkSteelArmor implements IStellarItem, IHazardProtector {
 
     public static final ArmorMaterial MATERIAL = EnumHelper
@@ -84,7 +84,7 @@ public class ItemStellarArmor extends ItemDarkSteelArmor implements IStellarItem
     }
 
     /// GT5 Hazmat protection
-    @Optional.Method(modid = "gregtechNH")
+    @Optional.Method(modid = "gregtech_nh")
     @Override
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return true;

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemStellarArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemStellarArmor.java
@@ -17,7 +17,7 @@ import crazypants.enderio.item.darksteel.upgrade.IDarkSteelUpgrade;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.hazards.IHazardProtector;
 
-@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft") })
+@Optional.InterfaceList({ @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH") })
 public class ItemStellarArmor extends ItemDarkSteelArmor implements IStellarItem, IHazardProtector {
 
     public static final ArmorMaterial MATERIAL = EnumHelper
@@ -84,7 +84,7 @@ public class ItemStellarArmor extends ItemDarkSteelArmor implements IStellarItem
     }
 
     /// GT5 Hazmat protection
-    @Optional.Method(modid = "dreamcraft")
+    @Optional.Method(modid = "gregtechNH")
     @Override
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return true;


### PR DESCRIPTION
If standalone gt5 also uses this api then the compat will have to change back to a check for gregtech but only if gregapi isn't loaded, not sure if its possible on the optional decorator