### PR TITLE
Fix gt loader check without touching Optional decorators for now

### DIFF
--- a/src/main/java/crazypants/enderio/EnderIO.java
+++ b/src/main/java/crazypants/enderio/EnderIO.java
@@ -208,7 +208,7 @@ public class EnderIO {
     public static final Lang lang = new Lang("enderio");
 
     public static final boolean hasLwjgl3 = Loader.isModLoaded("lwjgl3ify");
-    public static final boolean hasGT5 = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi_post");
+    public static final boolean hasGT5 = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
 
     // Materials
     public static ItemCapacitor itemBasicCapacitor;


### PR DESCRIPTION
This should have no effect with gt5 and fix some of the current issues with gt6 compat