### PR TITLE
Comparator refactor and Vacuum Chest logic

### DIFF
--- a/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
@@ -523,19 +523,6 @@ public class BlockCapBank extends BlockEio
         return AxisAlignedBB.getBoundingBox(min.x, min.y, min.z, max.x, max.y, max.z);
     }
 
-    @Override
-    public boolean hasComparatorInputOverride() {
-        return true;
-    }
-
-    @Override
-    public int getComparatorInputOverride(World w, int x, int y, int z, int side) {
-        TileEntity te = w.getTileEntity(x, y, z);
-        if (te instanceof TileCapBank) {
-            return ((TileCapBank) te).getComparatorOutput();
-        }
-        return 0;
-    }
 
     @Override
     public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {

--- a/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
@@ -523,7 +523,6 @@ public class BlockCapBank extends BlockEio
         return AxisAlignedBB.getBoundingBox(min.x, min.y, min.z, max.x, max.y, max.z);
     }
 
-
     @Override
     public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
         TileEntity te = world.getTileEntity(x, y, z);

--- a/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.enderio.core.common.interfaces.IComparatorOutput;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -19,6 +18,7 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.enderio.core.common.interfaces.IComparatorOutput;
 import com.enderio.core.common.util.BlockCoord;
 import com.enderio.core.common.util.EntityUtil;
 import com.enderio.core.common.util.Util;

--- a/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.enderio.core.common.interfaces.IComparatorOutput;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -46,7 +47,7 @@ import crazypants.enderio.power.IPowerStorage;
 import crazypants.enderio.power.PowerHandlerUtil;
 
 public class TileCapBank extends TileEntityEio
-        implements IInternalPowerReceiver, IInventory, IIoConfigurable, IPowerStorage {
+        implements IInternalPowerReceiver, IInventory, IIoConfigurable, IPowerStorage, IComparatorOutput {
 
     private Map<ForgeDirection, IoMode> faceModes;
     private Map<ForgeDirection, InfoDisplayType> faceDisplayTypes;
@@ -692,6 +693,7 @@ public class TileCapBank extends TileEntityEio
         return getIoMode(from) != IoMode.DISABLED;
     }
 
+    @Override
     public int getComparatorOutput() {
         double stored = getEnergyStored();
         return stored == 0 ? 0 : (int) (1 + stored / getMaxEnergyStored() * 14);

--- a/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
@@ -695,8 +695,8 @@ public class TileCapBank extends TileEntityEio
 
     @Override
     public int getComparatorOutput() {
-        double stored = getEnergyStored();
-        return stored == 0 ? 0 : (int) (1 + stored / getMaxEnergyStored() * 14);
+        int stored = getEnergyStored();
+        return stored == 0 ? 0 : 1 + (stored * 14) / getMaxEnergyStored();
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/power/BlockCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/BlockCapacitorBank.java
@@ -331,20 +331,6 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
     }
 
     @Override
-    public boolean hasComparatorInputOverride() {
-        return true;
-    }
-
-    @Override
-    public int getComparatorInputOverride(World w, int x, int y, int z, int side) {
-        TileEntity te = w.getTileEntity(x, y, z);
-        if (te instanceof TileCapacitorBank) {
-            return ((TileCapacitorBank) te).getComparatorOutput();
-        }
-        return 0;
-    }
-
-    @Override
     public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
         TileEntity te = world.getTileEntity(x, y, z);
         if (te instanceof TileCapacitorBank) {

--- a/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
@@ -7,7 +7,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.enderio.core.common.interfaces.IComparatorOutput;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -18,6 +17,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.enderio.core.common.interfaces.IComparatorOutput;
 import com.enderio.core.common.util.BlockCoord;
 import com.enderio.core.common.util.Util;
 import com.enderio.core.common.vecmath.VecmathUtil;

--- a/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
@@ -7,6 +7,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.enderio.core.common.interfaces.IComparatorOutput;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -40,7 +41,7 @@ import crazypants.enderio.power.IPowerStorage;
 import crazypants.enderio.power.PowerHandlerUtil;
 
 public class TileCapacitorBank extends TileEntityEio
-        implements IInternalPowerHandler, IInventory, IIoConfigurable, IPowerStorage {
+        implements IInternalPowerHandler, IInventory, IIoConfigurable, IPowerStorage, IComparatorOutput {
 
     static final BasicCapacitor BASE_CAP = new BasicCapacitor(
             Config.capacitorBankMaxIoRF,
@@ -273,6 +274,7 @@ public class TileCapacitorBank extends TileEntityEio
         }
     }
 
+    @Override
     public int getComparatorOutput() {
         double stored = getEnergyStored();
         return stored == 0 ? 0 : (int) (1 + stored / getMaxEnergyStored() * 14);

--- a/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
@@ -276,8 +276,8 @@ public class TileCapacitorBank extends TileEntityEio
 
     @Override
     public int getComparatorOutput() {
-        double stored = getEnergyStored();
-        return stored == 0 ? 0 : (int) (1 + stored / getMaxEnergyStored() * 14);
+        int stored = getEnergyStored();
+        return stored == 0 ? 0 : 1 + (stored * 14) / getMaxEnergyStored();
     }
 
     public List<GaugeBounds> getGaugeBounds() {

--- a/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
@@ -185,20 +185,6 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
     }
 
     @Override
-    public boolean hasComparatorInputOverride() {
-        return true;
-    }
-
-    @Override
-    public int getComparatorInputOverride(World w, int x, int y, int z, int side) {
-        TileEntity te = w.getTileEntity(x, y, z);
-        if (te instanceof TileTank) {
-            return ((TileTank) te).getComparatorOutput();
-        }
-        return 0;
-    }
-
-    @Override
     @SideOnly(Side.CLIENT)
     public void addBasicEntries(ItemStack itemstack, EntityPlayer entityplayer, List<String> list, boolean flag) {
         if (itemstack.stackTagCompound != null && itemstack.stackTagCompound.hasKey("tankContents")) {

--- a/src/main/java/crazypants/enderio/machine/tank/TileTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/TileTank.java
@@ -305,7 +305,7 @@ public class TileTank extends AbstractMachineEntity implements IFluidHandler, IT
             return 0;
         }
 
-        return info.fluid.amount == 0 ? 0 : (int) (1 + ((double) info.fluid.amount / (double) info.capacity) * 14);
+        return info.fluid.amount == 0 ? 0 : 1 + (info.fluid.amount * 14) / info.capacity;
     }
 
     private boolean processItems(boolean redstoneCheckPassed) {

--- a/src/main/java/crazypants/enderio/machine/tank/TileTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/TileTank.java
@@ -1,5 +1,6 @@
 package crazypants.enderio.machine.tank;
 
+import com.enderio.core.common.interfaces.IComparatorOutput;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -28,7 +29,7 @@ import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.tool.ArrayMappingTool;
 import crazypants.enderio.tool.SmartTank;
 
-public class TileTank extends AbstractMachineEntity implements IFluidHandler, ITankAccess {
+public class TileTank extends AbstractMachineEntity implements IFluidHandler, ITankAccess, IComparatorOutput {
 
     private static int IO_MB_TICK = 100;
 
@@ -297,6 +298,7 @@ public class TileTank extends AbstractMachineEntity implements IFluidHandler, IT
         return res;
     }
 
+    @Override
     public int getComparatorOutput() {
         FluidTankInfo info = getTankInfo(null)[0];
         if (info == null || info.fluid == null) {

--- a/src/main/java/crazypants/enderio/machine/tank/TileTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/TileTank.java
@@ -1,6 +1,5 @@
 package crazypants.enderio.machine.tank;
 
-import com.enderio.core.common.interfaces.IComparatorOutput;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -16,6 +15,7 @@ import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
 
 import com.enderio.core.api.common.util.ITankAccess;
+import com.enderio.core.common.interfaces.IComparatorOutput;
 import com.enderio.core.common.util.BlockCoord;
 import com.enderio.core.common.util.FluidUtil;
 import com.enderio.core.common.util.FluidUtil.FluidAndStackResult;

--- a/src/main/java/crazypants/enderio/machine/vacuum/TileVacuumChest.java
+++ b/src/main/java/crazypants/enderio/machine/vacuum/TileVacuumChest.java
@@ -2,7 +2,6 @@ package crazypants.enderio.machine.vacuum;
 
 import java.util.List;
 
-import com.enderio.core.common.interfaces.IComparatorOutput;
 import net.minecraft.block.Block;
 import net.minecraft.command.IEntitySelector;
 import net.minecraft.entity.Entity;
@@ -18,6 +17,7 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 
 import com.enderio.core.client.render.BoundingBox;
+import com.enderio.core.common.interfaces.IComparatorOutput;
 import com.enderio.core.common.util.ItemUtil;
 import com.enderio.core.common.vecmath.Vector3d;
 

--- a/src/main/java/crazypants/enderio/machine/vacuum/TileVacuumChest.java
+++ b/src/main/java/crazypants/enderio/machine/vacuum/TileVacuumChest.java
@@ -2,12 +2,14 @@ package crazypants.enderio.machine.vacuum;
 
 import java.util.List;
 
+import com.enderio.core.common.interfaces.IComparatorOutput;
 import net.minecraft.block.Block;
 import net.minecraft.command.IEntitySelector;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.IProjectile;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -34,7 +36,7 @@ import crazypants.enderio.machine.ranged.IRanged;
 import crazypants.enderio.machine.ranged.RangeEntity;
 
 public class TileVacuumChest extends TileEntityEio
-        implements IEntitySelector, IInventory, IRedstoneModeControlable, IRanged {
+        implements IEntitySelector, IInventory, IRedstoneModeControlable, IRanged, IComparatorOutput {
 
     public static final int ITEM_ROWS = 3;
     public static final int ITEM_SLOTS = 9 * ITEM_ROWS;
@@ -406,5 +408,10 @@ public class TileVacuumChest extends TileEntityEio
             nbtRoot.setTag("filter", filterNBT);
         }
         nbtRoot.setInteger("redstoneControlMode", redstoneControlMode.ordinal());
+    }
+
+    @Override
+    public int getComparatorOutput() {
+        return Container.calcRedstoneFromInventory(this);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19692

This PR adds comparator logic to the Vacuum chest, but more importantly completes an already half-done effort to move all base comparator impl to BlockEnder, and then hold the actual functions for comparator output strength in the TileEntity as an implementation of IComparatorOutput.