### PR TITLE
Break Dependency Chain

### DIFF
--- a/src/main/java/crazypants/enderio/EnderIO.java
+++ b/src/main/java/crazypants/enderio/EnderIO.java
@@ -190,7 +190,6 @@ import crazypants.util.EE3Util;
         after:Waila@[1.5.8,);\
         after:Thaumcraft;\
         after:appliedenergistics2@[rv2-beta-8,);\
-        after:chisel;\
         after:Railcraft@[9.16.7,)\
         """, guiFactory = "crazypants.enderio.config.ConfigFactoryEIO")
 public class EnderIO {


### PR DESCRIPTION
Swapping this to `before:chisel` in dev caused no problems, so it can probably just be removed outright. The only thing from Chisel in EnderIO is an [optional interface](https://github.com/search?q=repo%3AGTNewHorizons%2FEnderIO%20chisel&type=code) for painted conduit facades and the like which still works fine:
<img width="2560" height="1414" alt="blocks" src="https://github.com/user-attachments/assets/2121eed4-ff9c-4104-85cb-3ea25dbc3967" />
<img width="2560" height="1414" alt="wrench" src="https://github.com/user-attachments/assets/cd0aa0a3-f4a4-4c02-9ae9-b1cbaa53ba51" />
