### PR TITLE
Fix crash when breaking Painted Glowstone placed by Better Builders Wand

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,7 @@ dependencies {
     api("com.github.GTNewHorizons:TinkersConstruct:1.13.54-GTNH:dev")
 
     compileOnly('com.github.GTNewHorizons:waila:1.8.14:api') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-688-GTNH:api') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-689-GTNH:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Baubles:1.0.4:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.464:dev') {transitive = false}
     compileOnly("com.github.GTNewHorizons:ModularUI2:2.2.18-1.7.10:dev") {transitive = false}

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedGlowstone.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedGlowstone.java
@@ -199,7 +199,7 @@ public class BlockPaintedGlowstone extends BlockEio
     @SideOnly(Side.CLIENT)
     @Override
     public void registerBlockIcons(IIconRegister IIconRegister) {
-        blockIcon = IIconRegister.registerIcon("enderio:conduitConnector");
+        blockIcon = IIconRegister.registerIcon("glowstone");
     }
 
     @Override
@@ -231,10 +231,12 @@ public class BlockPaintedGlowstone extends BlockEio
 
     @Override
     protected void processDrop(World world, int x, int y, int z, TileEntityEnder te, ItemStack drop) {
-        TileEntityPaintedBlock tef = (TileEntityPaintedBlock) te;
-        if (tef != null) {
+        if (te instanceof TileEntityPaintedBlock tef) {
             ItemStack itemStack = createItemStackForSourceBlock(tef.getSourceBlock(), tef.getSourceBlockMetadata());
-            drop.stackTagCompound = (NBTTagCompound) itemStack.stackTagCompound.copy();
+            NBTTagCompound tag = itemStack.stackTagCompound;
+            if (tag != null) {
+                drop.stackTagCompound = (NBTTagCompound) tag.copy();
+            }
         }
     }
 

--- a/src/main/java/crazypants/enderio/machine/painter/PainterUtil.java
+++ b/src/main/java/crazypants/enderio/machine/painter/PainterUtil.java
@@ -63,7 +63,8 @@ public final class PainterUtil {
                 sourceName = is.getDisplayName();
             }
         }
-        return EnderIO.lang.localize("blockPainter.paintedWith") + " " + (sourceName.isEmpty() ? EnderIO.lang.localize("blockPainter.paintedWith.none") : sourceName);
+        return EnderIO.lang.localize("blockPainter.paintedWith") + " "
+                + (sourceName.isEmpty() ? EnderIO.lang.localize("blockPainter.paintedWith.none") : sourceName);
     }
 
     public static void setSourceBlock(ItemStack item, Block source, int meta) {

--- a/src/main/java/crazypants/enderio/machine/painter/PainterUtil.java
+++ b/src/main/java/crazypants/enderio/machine/painter/PainterUtil.java
@@ -63,7 +63,7 @@ public final class PainterUtil {
                 sourceName = is.getDisplayName();
             }
         }
-        return EnderIO.lang.localize("blockPainter.paintedWith") + " " + sourceName;
+        return EnderIO.lang.localize("blockPainter.paintedWith") + " " + (sourceName.isEmpty() ? EnderIO.lang.localize("blockPainter.paintedWith.none") : sourceName);
     }
 
     public static void setSourceBlock(ItemStack item, Block source, int meta) {

--- a/src/main/resources/assets/enderio/lang/en_US.lang
+++ b/src/main/resources/assets/enderio/lang/en_US.lang
@@ -777,6 +777,7 @@ enderio.itemCoordSelector.chat.setDimension=Set Dimension: %s%s
 #Painter
 tile.blockPainter.name=Painting Machine
 enderio.blockPainter.paintedWith=Painted with:
+enderio.blockPainter.paintedWith.none=§onothing§r
 tile.blockPaintedFence.name=Painted Fence
 tile.blockPaintedFenceGate.name=Painted Gate
 tile.blockPaintedWall.name=Painted Wall


### PR DESCRIPTION
Better Builders Wands can place Painted Glowstone blocks but without necessary NBT data which trips up EnderIO. This fixes the crashing, but doesn't actually fix the problem that Better Builders Wands can't build Painted Glowstone in the first place (whereas ExU Builders Wand can). A fix for that would be more involved.

Besides the actual null check to fix the crashing, this gives "null" (aka unpainted) Glowstone the Glowstone texture.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21177