### PR TITLE
Add automation to EIO Enchanter (basically a copy-paste from my other two PR's)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     api('com.github.GTNewHorizons:EnderCore:0.5.7:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ForestryMC:4.11.4:dev')
     compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.8.60-GTNH:dev')
-    api("com.github.GTNewHorizons:GTNHLib:0.9.10:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.9.47:dev")
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.55:dev')
     api('curse.maven:cofh-lib-220333:2388748') // https://www.curseforge.com/minecraft/mc-mods/cofh-lib/files/2388748
     shadowImplementation('cglib:cglib-nodep:3.3.0')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -29,4 +29,5 @@ dependencies {
 
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta66a:api') {transitive = false}
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.7.58:dev")
+    compileOnly('curse.maven:automagy-222153:2285272')
 }

--- a/src/main/java/crazypants/enderio/EnderIO.java
+++ b/src/main/java/crazypants/enderio/EnderIO.java
@@ -215,6 +215,7 @@ public class EnderIO {
     public static final boolean hasGT5 = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
     public static final boolean hasHP = Loader.isModLoaded("hodgepodge");
     public static final boolean hasWailaPlugins = Loader.isModLoaded("wailaplugins");
+    public static final boolean hasAutomagy = Loader.isModLoaded("Automagy");
 
     // Materials
     public static ItemCapacitor itemBasicCapacitor;

--- a/src/main/java/crazypants/enderio/machine/enchanter/BlockEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/BlockEnchanter.java
@@ -148,6 +148,8 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
     }
 
     // 0, 1, 2, 3, 4, 5, 8, 12, 20, 24, 32, 36, 48, 60, 64 are 0-15 respectively
+    // the power values are all possible values of the second slot to make automation possible
+    // (it has to be able to differentiate from them all)
     @Override
     public int getComparatorInputOverride(World worldIn, int x, int y, int z, int side) {
         if (worldIn.getTileEntity(x, y, z) instanceof IInventory inv) {

--- a/src/main/java/crazypants/enderio/machine/enchanter/BlockEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/BlockEnchanter.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import net.minecraft.block.Block;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
@@ -139,5 +140,24 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
     @Override
     public String getUnlocalizedNameForTooltip(ItemStack itemStack) {
         return getUnlocalizedName();
+    }
+
+    @Override
+    public boolean hasComparatorInputOverride() {
+        return true;
+    }
+
+    // 0, 1, 2, 3, 4, 5, 8, 12, 20, 24, 32, 36, 48, 60, 64 are 0-15 respectively
+    @Override
+    public int getComparatorInputOverride(World worldIn, int x, int y, int z, int side) {
+        if (worldIn.getTileEntity(x, y, z) instanceof IInventory inv) {
+            ItemStack stuff = inv.getStackInSlot(1);
+            int size;
+            return stuff == null ? 0
+                    : (size = stuff.stackSize) < 6 ? size
+                            : size < 40 ? size / 4 + (size < 28 ? 4 : 3)
+                                    : size < 48 ? 12 : size < 60 ? 13 : size < 64 ? 14 : 15;
+        }
+        return 0;
     }
 }

--- a/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
@@ -29,7 +29,7 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
 
             // @Override
             // public int getSlotStackLimit() {
-            //     return 1;
+            // return 1;
             // }
 
             @Override
@@ -92,7 +92,7 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
                     te.markDirty();
                 }
 
-                curStack = te.getStackInSlot(0)
+                curStack = te.getStackInSlot(0);
                 if (curStack == null || curStack.stackSize <= 1) te.setInventorySlotContents(0, null);
                 else {
                     curStack = curStack.copy();

--- a/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
@@ -39,7 +39,7 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
 
             @Override
             public void onSlotChanged() {
-                updateOutput();
+                // updateOutput();
             }
         });
 
@@ -52,7 +52,7 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
 
             @Override
             public void onSlotChanged() {
-                updateOutput();
+                // updateOutput();
             }
         });
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
@@ -86,7 +86,6 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
                         || enchData.enchantmentLevel >= curStack.stackSize) {
                     te.setInventorySlotContents(1, (ItemStack) null);
                 } else {
-
                     curStack = curStack.copy();
                     curStack.stackSize -= recipe.getItemsPerLevel() * enchData.enchantmentLevel;
                     if (curStack.stackSize > 0) {

--- a/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
@@ -27,10 +27,10 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
 
         addSlotToContainer(new Slot(te, 0, 27, 35) {
 
-            @Override
-            public int getSlotStackLimit() {
-                return 1;
-            }
+            // @Override
+            // public int getSlotStackLimit() {
+            //     return 1;
+            // }
 
             @Override
             public boolean isItemValid(ItemStack itemStack) {
@@ -92,7 +92,13 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
                     te.markDirty();
                 }
 
-                te.setInventorySlotContents(0, (ItemStack) null);
+                curStack = te.getStackInSlot(0)
+                if (curStack == null || curStack.stackSize <= 1) te.setInventorySlotContents(0, null);
+                else {
+                    curStack = curStack.copy();
+                    curStack.stackSize -= 1;
+                    te.setInventorySlotContents(0, curStack);
+                }
                 if (!te.getWorldObj().isRemote) {
                     te.getWorldObj().playAuxSFX(1021, te.xCoord, te.yCoord, te.zCoord, 0);
                 }

--- a/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
@@ -59,6 +59,11 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
         addSlotToContainer(new Slot(te, 2, 134, 35) {
 
             @Override
+            public ItemStack decrStackSize(int amt) {
+                return te.decrStackSize(2, amt, false);
+            }
+
+            @Override
             public int getSlotStackLimit() {
                 return 1;
             }

--- a/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
@@ -27,11 +27,6 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
 
         addSlotToContainer(new Slot(te, 0, 27, 35) {
 
-            // @Override
-            // public int getSlotStackLimit() {
-            // return 1;
-            // }
-
             @Override
             public boolean isItemValid(ItemStack itemStack) {
                 return te.isItemValidForSlot(0, itemStack);

--- a/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
@@ -81,11 +81,8 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
                         || enchData.enchantmentLevel >= curStack.stackSize) {
                     te.setInventorySlotContents(1, (ItemStack) null);
                 } else {
-                    curStack = curStack.copy();
                     curStack.stackSize -= recipe.getItemsPerLevel() * enchData.enchantmentLevel;
-                    if (curStack.stackSize > 0) {
-                        te.setInventorySlotContents(1, curStack);
-                    } else {
+                    if (curStack.stackSize <= 0) {
                         te.setInventorySlotContents(1, null);
                     }
                     te.markDirty();
@@ -94,7 +91,6 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
                 curStack = te.getStackInSlot(0);
                 if (curStack == null || curStack.stackSize <= 1) te.setInventorySlotContents(0, null);
                 else {
-                    curStack = curStack.copy();
                     curStack.stackSize -= 1;
                     te.setInventorySlotContents(0, curStack);
                 }

--- a/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/ContainerEnchanter.java
@@ -39,7 +39,7 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
 
             @Override
             public void onSlotChanged() {
-                // updateOutput();
+                updateOutput();
             }
         });
 
@@ -52,7 +52,7 @@ public class ContainerEnchanter extends ContainerEnderTileEntity<TileEnchanter> 
 
             @Override
             public void onSlotChanged() {
-                // updateOutput();
+                updateOutput();
             }
         });
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -11,10 +11,8 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import com.enderio.core.api.common.util.IProgressTile;
 import com.gtnewhorizon.gtnhlib.geometry.CubeIterator;
 
 import crazypants.enderio.ModObject;
@@ -25,7 +23,7 @@ import crazypants.enderio.xp.ExperienceContainer;
 import crazypants.enderio.xp.XpUtil;
 import tuhljin.automagy.tiles.TileEntityJarXP;
 
-public class TileEnchanter extends TileEntityEio implements ISidedInventory, IProgressTile {
+public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     private ItemStack[] inv = new ItemStack[3];
     private int[] stacksizes = { 0, 0 };
@@ -51,19 +49,6 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory, IPr
     @Override
     public boolean shouldUpdate() {
         return inv[0] != null && inv[1] != null;
-    }
-
-    @Override
-    public float getProgress() {
-        return 0;
-    }
-
-    @Override
-    public void setProgress(float progress) {}
-
-    @Override
-    public TileEntity getTileEntity() {
-        return this;
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -2,6 +2,8 @@ package crazypants.enderio.machine.enchanter;
 
 import static crazypants.enderio.EnderIO.hasAutomagy;
 
+import java.util.ArrayList;
+
 import net.minecraft.enchantment.EnchantmentData;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -16,7 +18,10 @@ import com.gtnewhorizon.gtnhlib.geometry.CubeIterator;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.config.Config;
+import crazypants.enderio.machine.obelisk.xp.TileExperienceObelisk;
+import crazypants.enderio.xp.ExperienceContainer;
 import crazypants.enderio.xp.XpUtil;
+import tuhljin.automagy.tiles.TileEntityJarXP;
 
 public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
@@ -108,9 +113,10 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         int LV = getCurrentEnchantmentCost();
         if (LV == 0) return false;
         // xp *= amt;
-        int xpCost = XpUtil.getExperienceForLevel(LV*amt);
+        int xpCost = XpUtil.getExperienceForLevel(LV * amt);
         int xp;
         absorb: {
+            ArrayList<ExperienceContainer> obelisksToEmpty = new ArrayList<>();
             if (true) {
                 CubeIterator iter = new CubeIterator(8);
                 while (iter.hasNext()) {
@@ -123,7 +129,6 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                         xp = cont.getExperienceTotal();
                         if (xp >= xpCost) {
                             if (!worldObj.isRemote) {
-                                jarsToEmpty.forEach(j -> j.setXP(0));
                                 obelisksToEmpty.forEach(o -> o.drain(null, Integer.MAX_VALUE, true));
                                 cont.drain(null, Integer.MAX_VALUE, true);
                                 cont.addExperience(Math.max(0, xp - xpCost));
@@ -136,6 +141,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                 }
             }
             if (hasAutomagy) {
+                ArrayList<TileEntityJarXP> jarsToEmpty = new ArrayList<>();
                 CubeIterator iter = new CubeIterator(8);
                 while (iter.hasNext()) {
                     iter.next();
@@ -146,6 +152,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                         xp = jar.getXP();
                         if (xp >= xpCost) {
                             if (!worldObj.isRemote) {
+                                obelisksToEmpty.forEach(o -> o.drain(null, Integer.MAX_VALUE, true));
                                 jarsToEmpty.forEach(j -> j.setXP(0));
                                 jar.setXP(xp - xpCost);
                             }

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -217,7 +217,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         }
         if (inv[2] != null || inv[0] == null || inv[1] == null) return;
         ItemStack output = null;
-        EnchantmentData enchantment = getInv().getCurrentEnchantmentData();
+        EnchantmentData enchantment = getCurrentEnchantmentData();
         if (enchantment != null) {
             output = new ItemStack(Items.enchanted_book);
             Items.enchanted_book.addEnchantment(output, enchantment);

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -235,6 +235,9 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             Items.enchanted_book.addEnchantment(output, enchantment);
         }
         setOutput(output);
+
+        if (inv[0] != null) stacksizes[0] = inv[0].stackSize;
+        if (inv[1] != null) stacksizes[1] = inv[1].stackSize;
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -26,7 +26,7 @@ import tuhljin.automagy.tiles.TileEntityJarXP;
 public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     private final ItemStack[] inv = new ItemStack[3];
-    private final byte[] stacksizes = new byte[2];
+    private byte[] stacksizes = new byte[2];
 
     private short facing = (short) ForgeDirection.NORTH.ordinal();
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -26,7 +26,7 @@ import tuhljin.automagy.tiles.TileEntityJarXP;
 public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     private ItemStack[] inv = new ItemStack[3];
-    private int[] stacksizes = { 0, 0 };
+    private byte[] stacksizes = { 0, 0 };
 
     private short facing = (short) ForgeDirection.NORTH.ordinal();
 
@@ -39,7 +39,6 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
     }
 
     // The *ACTUAL* updateEntity and canUpdate are final in TileEntityEnder. Great.
-    // Now I have to make this pretend to be a progressable block; this is why you dont go crazy with final
 
     @Override
     protected void doUpdate() {
@@ -64,6 +63,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             }
         }
         root.setTag("Items", itemList);
+        root.setByteArray("SizeCache", stacksizes);
         root.setShort("facing", facing);
     }
 
@@ -79,6 +79,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                 }
             }
         }
+        stacksizes = root.getByteArray("SizeCache");
         facing = root.getShort("facing");
     }
 
@@ -237,8 +238,8 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         }
         setOutput(output);
 
-        if (inv[0] != null) stacksizes[0] = inv[0].stackSize;
-        if (inv[1] != null) stacksizes[1] = inv[1].stackSize;
+        if (inv[0] != null) stacksizes[0] = (byte) inv[0].stackSize;
+        if (inv[1] != null) stacksizes[1] = (byte) inv[1].stackSize;
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -108,6 +108,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             result.stackTagCompound = (NBTTagCompound) fromStack.stackTagCompound.copy();
         }
         fromStack.stackSize -= amount;
+        updateOut();
         return result;
     }
 
@@ -195,8 +196,9 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             setInventorySlotContents(0, curStack);
         }
         if (!worldObj.isRemote) {
-            worldObj.playSoundEffect(xCoord + 0.5d, yCoord + 0.5d, zCoord + 0.5d, "block.anvil.place", 0.2f, 1.0f);
+            worldObj.playSoundEffect(xCoord + 0.5d, yCoord + 0.5d, zCoord + 0.5d, "random.anvil_land", 0.2f, 1.0f);
         }
+        updateOut();
         return false;
     }
 
@@ -215,7 +217,10 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         if (contents != null && contents.stackSize > getInventoryStackLimit()) {
             contents.stackSize = getInventoryStackLimit();
         }
-        if (inv[2] != null || inv[0] == null || inv[1] == null) return;
+        updateOut();
+    }
+
+    public void updateOut() {
         ItemStack output = null;
         EnchantmentData enchantment = getCurrentEnchantmentData();
         if (enchantment != null) {

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -1,6 +1,6 @@
 package crazypants.enderio.machine.enchanter;
 
-import static crazypants.enderio.EnderIO.isAutomagyLoaded;
+import static crazypants.enderio.EnderIO.hasAutomagy;
 
 import net.minecraft.enchantment.EnchantmentData;
 import net.minecraft.entity.player.EntityPlayer;
@@ -135,7 +135,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                     }
                 }
             }
-            if (isAutomagyLoaded) {
+            if (hasAutomagy) {
                 CubeIterator iter = new CubeIterator(8);
                 while (iter.hasNext()) {
                     iter.next();

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -11,8 +11,10 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.enderio.core.api.common.util.IProgressTile;
 import com.gtnewhorizon.gtnhlib.geometry.CubeIterator;
 
 import crazypants.enderio.ModObject;
@@ -23,9 +25,10 @@ import crazypants.enderio.xp.ExperienceContainer;
 import crazypants.enderio.xp.XpUtil;
 import tuhljin.automagy.tiles.TileEntityJarXP;
 
-public class TileEnchanter extends TileEntityEio implements ISidedInventory {
+public class TileEnchanter extends TileEntityEio implements ISidedInventory, IProgressTile {
 
     private ItemStack[] inv = new ItemStack[3];
+    private int[] stacksizes = { 0, 0 };
 
     private short facing = (short) ForgeDirection.NORTH.ordinal();
 
@@ -35,6 +38,32 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     public short getFacing() {
         return facing;
+    }
+
+    // The *ACTUAL* updateEntity and canUpdate are final in TileEntityEnder. Great.
+    // Now I have to make this pretend to be a progressable block; this is why you dont go crazy with final
+
+    @Override
+    protected void doUpdate() {
+        if (inv[0].stackSize != stacksizes[0] || inv[1].stackSize != stacksizes[1]) updateOut();
+    }
+
+    @Override
+    public boolean shouldUpdate() {
+        return inv[0] != null && inv[1] != null;
+    }
+
+    @Override
+    public float getProgress() {
+        return 0;
+    }
+
+    @Override
+    public void setProgress(float progress) {}
+
+    @Override
+    public TileEntity getTileEntity() {
+        return this;
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -26,7 +26,7 @@ import tuhljin.automagy.tiles.TileEntityJarXP;
 public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     private ItemStack[] inv = new ItemStack[3];
-    private byte[] stacksizes = { 0, 0 };
+    private byte[] stacksizes = new byte[2];
 
     private short facing = (short) ForgeDirection.NORTH.ordinal();
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -390,8 +390,8 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
     }
 
     @Override
-    public int[] getAccessibleSlotsFromSide(int p_94128_1_) {
-        return p_94128_1_ == 0 ? new int[] { 2 } : new int[] { 0, 1 };
+    public int[] getAccessibleSlotsFromSide(int side) {
+        return side == 0 ? new int[] { 2 } : new int[] { 0, 1 };
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -87,6 +87,10 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     @Override
     public ItemStack decrStackSize(int slot, int amount) {
+        return decrStackSize(slot, amount, true);
+    }
+
+    public ItemStack decrStackSize(int slot, int amount, boolean auto) {
         if (amount <= 0 || slot < 0 || slot >= inv.length || inv[slot] == null) {
             return null;
         }
@@ -94,7 +98,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         if (fromStack == null) {
             return null;
         }
-        if (slot == 2 && checkDrainXP(Math.min(amount, fromStack.stackSize))) return null;
+        if (slot == 2 && auto && checkDrainXP(Math.min(amount, fromStack.stackSize))) return null;
         if (fromStack.stackSize <= amount) {
             inv[slot] = null;
             return fromStack;

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -175,27 +175,20 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
         EnchantmentData enchData = getCurrentEnchantmentData();
         EnchanterRecipe recipe = getCurrentEnchantmentRecipe();
-        ItemStack curStack = getStackInSlot(1);
+        ItemStack curStack = inv[1];
         if (recipe == null || enchData == null || curStack == null || enchData.enchantmentLevel >= curStack.stackSize) {
-            setInventorySlotContents(1, (ItemStack) null);
+            inv[1] = null;
         } else {
             curStack = curStack.copy();
             curStack.stackSize -= recipe.getItemsPerLevel() * enchData.enchantmentLevel;
-            if (curStack.stackSize > 0) {
-                setInventorySlotContents(1, curStack);
-            } else {
-                setInventorySlotContents(1, null);
-            }
+            inv[1] = curStack.stackSize > 0 ? curStack : null;
             markDirty();
         }
 
-        curStack = getStackInSlot(0);
-        if (curStack == null || curStack.stackSize <= 1) setInventorySlotContents(0, null);
-        else {
-            curStack = curStack.copy();
-            curStack.stackSize -= 1;
-            setInventorySlotContents(0, curStack);
-        }
+        curStack = inv[0];
+        if (curStack == null || curStack.stackSize <= 1) inv[0] = null;
+        else inv[0].stackSize -= 1;
+
         if (!worldObj.isRemote) {
             worldObj.playSoundEffect(xCoord + 0.5d, yCoord + 0.5d, zCoord + 0.5d, "random.anvil_land", 0.2f, 1.0f);
         }

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -80,7 +80,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             }
         }
         stacksizes = root.getByteArray("SizeCache");
-        if (stacksizes == null || stacksizes.length < 2) stacksizes = new int[2];
+        if (stacksizes == null || stacksizes.length < 2) stacksizes = new byte[2];
         facing = root.getShort("facing");
     }
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -25,8 +25,8 @@ import tuhljin.automagy.tiles.TileEntityJarXP;
 
 public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
-    private ItemStack[] inv = new ItemStack[3];
-    private byte[] stacksizes = new byte[2];
+    private final ItemStack[] inv = new ItemStack[3];
+    private final byte[] stacksizes = new byte[2];
 
     private short facing = (short) ForgeDirection.NORTH.ordinal();
 
@@ -115,7 +115,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         if (fromStack == null) {
             return null;
         }
-        if (slot == 2 && auto && checkDrainXP(Math.min(amount, fromStack.stackSize))) return null;
+        if (slot == 2 && auto && checkAndDrainXP(Math.min(amount, fromStack.stackSize))) return null;
         if (fromStack.stackSize <= amount) {
             inv[slot] = null;
             updateOut();
@@ -130,9 +130,8 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         return result;
     }
 
-    // checks AND drains XP; returns true if xp is NOT sufficient
-    // also removes the items from the other two slots when automation does the recipe
-    public boolean checkDrainXP(int amt) {
+    // part of the next method
+    public boolean absorbXP(int amt) {
         if (inv[2] == null || amt <= 0 || inv[2].stackSize < amt) return true;
         int LV = getCurrentEnchantmentCost();
         if (LV == 0) return false;
@@ -156,7 +155,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                                 cont.drain(null, Integer.MAX_VALUE, true);
                                 cont.addExperience(Math.max(0, xp - xpCost));
                             }
-                            break absorb;
+                            return false;
                         }
                         xpCost -= xp;
                         obelisksToEmpty.add(cont);
@@ -179,7 +178,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                                 jarsToEmpty.forEach(j -> j.setXP(0));
                                 jar.setXP(xp - xpCost);
                             }
-                            break absorb;
+                            return false;
                         }
                         xpCost -= xp;
                         jarsToEmpty.add(jar);
@@ -188,7 +187,13 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             }
             return true;
         }
+        return false;
+    }
 
+    // checks AND drains XP; returns true if xp is NOT sufficient
+    // also removes the items from the other two slots when automation does the recipe
+    public boolean checkAndDrainXP(int amt) {
+        if (absorbXP(amt)) return true;
         EnchantmentData enchData = getCurrentEnchantmentData();
         EnchanterRecipe recipe = getCurrentEnchantmentRecipe();
         ItemStack curStack = inv[1];

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -26,7 +26,7 @@ import tuhljin.automagy.tiles.TileEntityJarXP;
 public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     private ItemStack[] inv = new ItemStack[3];
-    private byte[] stacksizes = { 0, 0 };
+    private byte[] stacksizes = new byte[2];
 
     private short facing = (short) ForgeDirection.NORTH.ordinal();
 
@@ -42,12 +42,12 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     @Override
     protected void doUpdate() {
-        if (!shouldUpdate()) return;
+        if (!shouldUpdate_()) return;
         if (inv[0].stackSize != stacksizes[0] || inv[1].stackSize != stacksizes[1]) updateOut();
     }
 
-    @Override
-    public boolean shouldUpdate() {
+    // @Override
+    public boolean shouldUpdate_() {
         return inv[0] != null && inv[1] != null;
     }
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -136,7 +136,6 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         if (inv[2] == null || amt <= 0 || inv[2].stackSize < amt) return true;
         int LV = getCurrentEnchantmentCost();
         if (LV == 0) return false;
-        // xp *= amt;
         int xpCost = XpUtil.getExperienceForLevel(LV * amt);
         int xp;
         absorb: {

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -112,6 +112,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
     }
 
     // checks AND drains XP; returns true if xp is NOT sufficient
+    // also removes the items from the other two slots when automation does the recipe
     public boolean checkDrainXP(int amt) {
         if (inv[2] == null || amt <= 0 || inv[2].stackSize < amt) return true;
         int LV = getCurrentEnchantmentCost();
@@ -137,7 +138,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                                 cont.drain(null, Integer.MAX_VALUE, true);
                                 cont.addExperience(Math.max(0, xp - xpCost));
                             }
-                            return false; // break absorb;
+                            break absorb;
                         }
                         xpCost -= xp;
                         obelisksToEmpty.add(cont);
@@ -160,7 +161,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
                                 jarsToEmpty.forEach(j -> j.setXP(0));
                                 jar.setXP(xp - xpCost);
                             }
-                            return false; // break absorb;
+                            break absorb;
                         }
                         xpCost -= xp;
                         jarsToEmpty.add(jar);
@@ -169,6 +170,34 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             }
             return true;
         }
+
+        EnchantmentData enchData = getCurrentEnchantmentData();
+        EnchanterRecipe recipe = getCurrentEnchantmentRecipe();
+        ItemStack curStack = getStackInSlot(1);
+        if (recipe == null || enchData == null || curStack == null || enchData.enchantmentLevel >= curStack.stackSize) {
+            setInventorySlotContents(1, (ItemStack) null);
+        } else {
+            curStack = curStack.copy();
+            curStack.stackSize -= recipe.getItemsPerLevel() * enchData.enchantmentLevel;
+            if (curStack.stackSize > 0) {
+                setInventorySlotContents(1, curStack);
+            } else {
+                setInventorySlotContents(1, null);
+            }
+            markDirty();
+        }
+
+        curStack = getStackInSlot(0);
+        if (curStack == null || curStack.stackSize <= 1) setInventorySlotContents(0, null);
+        else {
+            curStack = curStack.copy();
+            curStack.stackSize -= 1;
+            setInventorySlotContents(0, curStack);
+        }
+        if (!worldObj.isRemote) {
+            worldObj.playSoundEffect(xCoord + 0.5d, yCoord + 0.5d, zCoord + 0.5d, "block.anvil.place", 0.2f, 1.0f);
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -43,6 +43,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     @Override
     protected void doUpdate() {
+        if (!shouldUpdate()) return;
         if (inv[0].stackSize != stacksizes[0] || inv[1].stackSize != stacksizes[1]) updateOut();
     }
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -215,6 +215,14 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         if (contents != null && contents.stackSize > getInventoryStackLimit()) {
             contents.stackSize = getInventoryStackLimit();
         }
+        if (inv[2] != null || inv[0] == null || inv[1] == null) return;
+        ItemStack output = null;
+        EnchantmentData enchantment = getInv().getCurrentEnchantmentData();
+        if (enchantment != null) {
+            output = new ItemStack(Items.enchanted_book);
+            Items.enchanted_book.addEnchantment(output, enchantment);
+        }
+        setOutput(output);
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -1,5 +1,7 @@
 package crazypants.enderio.machine.enchanter;
 
+import static crazypants.enderio.EnderIO.isAutomagyLoaded;
+
 import net.minecraft.enchantment.EnchantmentData;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -9,9 +11,12 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.gtnewhorizon.gtnhlib.geometry.CubeIterator;
+
 import crazypants.enderio.ModObject;
 import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.config.Config;
+import crazypants.enderio.xp.XpUtil;
 
 public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
@@ -84,6 +89,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         if (fromStack == null) {
             return null;
         }
+        if (slot == 2 && checkDrainXP(Math.min(amount, fromStack.stackSize))) return null;
         if (fromStack.stackSize <= amount) {
             inv[slot] = null;
             return fromStack;
@@ -94,6 +100,64 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         }
         fromStack.stackSize -= amount;
         return result;
+    }
+
+    // checks AND drains XP; returns true if xp is NOT sufficient
+    public boolean checkDrainXP(int amt) {
+        if (inv[2] == null || amt <= 0 || inv[2].stackSize < amt) return true;
+        int LV = getCurrentEnchantmentCost();
+        if (LV == 0) return false;
+        // xp *= amt;
+        int xpCost = XpUtil.getExperienceForLevel(LV*amt);
+        int xp;
+        absorb: {
+            if (true) {
+                CubeIterator iter = new CubeIterator(8);
+                while (iter.hasNext()) {
+                    iter.next();
+                    if (worldObj.getTileEntity(
+                            iter.n + xCoord,
+                            iter.l + yCoord,
+                            iter.m + zCoord) instanceof TileExperienceObelisk obelisk) {
+                        ExperienceContainer cont = obelisk.getContainer();
+                        xp = cont.getExperienceTotal();
+                        if (xp >= xpCost) {
+                            if (!worldObj.isRemote) {
+                                jarsToEmpty.forEach(j -> j.setXP(0));
+                                obelisksToEmpty.forEach(o -> o.drain(null, Integer.MAX_VALUE, true));
+                                cont.drain(null, Integer.MAX_VALUE, true);
+                                cont.addExperience(Math.max(0, xp - xpCost));
+                            }
+                            return false; // break absorb;
+                        }
+                        xpCost -= xp;
+                        obelisksToEmpty.add(cont);
+                    }
+                }
+            }
+            if (isAutomagyLoaded) {
+                CubeIterator iter = new CubeIterator(8);
+                while (iter.hasNext()) {
+                    iter.next();
+                    if (worldObj.getTileEntity(
+                            iter.n + xCoord,
+                            iter.l + yCoord,
+                            iter.m + zCoord) instanceof TileEntityJarXP jar) {
+                        xp = jar.getXP();
+                        if (xp >= xpCost) {
+                            if (!worldObj.isRemote) {
+                                jarsToEmpty.forEach(j -> j.setXP(0));
+                                jar.setXP(xp - xpCost);
+                            }
+                            return false; // break absorb;
+                        }
+                        xpCost -= xp;
+                        jarsToEmpty.add(jar);
+                    }
+                }
+            }
+            return true;
+        }
     }
 
     @Override
@@ -226,7 +290,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         return getEnchantmentCost(getCurrentEnchantmentRecipe());
     }
 
-    private int getEnchantmentCost(EnchanterRecipe currentEnchantment) {
+    public int getEnchantmentCost(EnchanterRecipe currentEnchantment) {
         ItemStack item = inv[1];
         if (item == null) {
             return 0;
@@ -257,16 +321,16 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     @Override
     public int[] getAccessibleSlotsFromSide(int p_94128_1_) {
-        return new int[0];
+        return p_94128_1_ == 0 ? new int[] { 2 } : new int[] { 0, 1 };
     }
 
     @Override
     public boolean canInsertItem(int p_102007_1_, ItemStack p_102007_2_, int p_102007_3_) {
-        return false;
+        return true;
     }
 
     @Override
     public boolean canExtractItem(int p_102008_1_, ItemStack p_102008_2_, int p_102008_3_) {
-        return false;
+        return true;
     }
 }

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -198,7 +198,6 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         if (!worldObj.isRemote) {
             worldObj.playSoundEffect(xCoord + 0.5d, yCoord + 0.5d, zCoord + 0.5d, "random.anvil_land", 0.2f, 1.0f);
         }
-        updateOut();
         return false;
     }
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -26,7 +26,7 @@ import tuhljin.automagy.tiles.TileEntityJarXP;
 public class TileEnchanter extends TileEntityEio implements ISidedInventory {
 
     private ItemStack[] inv = new ItemStack[3];
-    private byte[] stacksizes = new byte[2];
+    private byte[] stacksizes = { 0, 0 };
 
     private short facing = (short) ForgeDirection.NORTH.ordinal();
 
@@ -80,6 +80,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             }
         }
         stacksizes = root.getByteArray("SizeCache");
+        if (stacksizes == null || stacksizes.length < 2) stacksizes = new int[2];
         facing = root.getShort("facing");
     }
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -187,7 +187,6 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
             }
             return true;
         }
-        return false;
     }
 
     // checks AND drains XP; returns true if xp is NOT sufficient

--- a/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/TileEnchanter.java
@@ -101,6 +101,7 @@ public class TileEnchanter extends TileEntityEio implements ISidedInventory {
         if (slot == 2 && auto && checkDrainXP(Math.min(amount, fromStack.stackSize))) return null;
         if (fromStack.stackSize <= amount) {
             inv[slot] = null;
+            updateOut();
             return fromStack;
         }
         ItemStack result = new ItemStack(fromStack.getItem(), amount, fromStack.getItemDamage());

--- a/src/main/resources/assets/enderio/lang/en_US.lang
+++ b/src/main/resources/assets/enderio/lang/en_US.lang
@@ -523,6 +523,9 @@ tile.blockEnchanter.name=Enchanter
 tile.blockEnchanter.tooltip.detailed.line1=Uses XP to combine items
 tile.blockEnchanter.tooltip.detailed.line2=and a book and quill to
 tile.blockEnchanter.tooltip.detailed.line3=created enchanted books
+tile.blockEnchanter.tooltip.detailed.line4=Outputs a comaprator signal
+tile.blockEnchanter.tooltip.detailed.line5=based on the second slot's
+tile.blockEnchanter.tooltip.detailed.line6=count, and works with hoppers
 
 tile.blockCombustionGenerator.name=Combustion Generator
 tile.blockCombustionGenerator.tooltip.detailed.line1=Burns liquid fuel to generate power

--- a/src/main/resources/assets/enderio/lang/en_US.lang
+++ b/src/main/resources/assets/enderio/lang/en_US.lang
@@ -523,7 +523,7 @@ tile.blockEnchanter.name=Enchanter
 tile.blockEnchanter.tooltip.detailed.line1=Uses XP to combine items
 tile.blockEnchanter.tooltip.detailed.line2=and a book and quill to
 tile.blockEnchanter.tooltip.detailed.line3=created enchanted books
-tile.blockEnchanter.tooltip.detailed.line4=Outputs a comaprator signal
+tile.blockEnchanter.tooltip.detailed.line4=Outputs a comparator signal
 tile.blockEnchanter.tooltip.detailed.line5=based on the second slot's
 tile.blockEnchanter.tooltip.detailed.line6=count, and works with hoppers
 


### PR DESCRIPTION
Following a suggestion from @EnderProyects (https://github.com/GTNewHorizons/Draconic-Evolution/pull/95#issuecomment-4166937348), I added automation to the EIO enchanter. Whenever a hopper takes an item from the output slot with `decrStackSize` it drains XP from an area, if possible, and if successful lets the hopper take the book. If using `setInventorySlotContents` this is bypassed to allow the GUI to still work, which is similar to how the Furnace does it, I think. Also, the amount of writable books allowed in the first slot as per the GUI is uncapped to 64 (it was capped to 1 for the gui but still 64 for automation), so now you can at the very least have a hopper that automatically feeds in writable books.