### PR TITLE
Fix sort order bounds check on Inventory Panel UI

### DIFF
--- a/src/main/java/crazypants/enderio/machine/invpanel/GuiInventoryPanel.java
+++ b/src/main/java/crazypants/enderio/machine/invpanel/GuiInventoryPanel.java
@@ -106,7 +106,7 @@ public class GuiInventoryPanel extends GuiMachineBase<TileInventoryPanel> {
         int sortMode = te.getGuiSortMode();
         int sortOrderIdx = sortMode >> 1;
         SortOrder[] orders = SortOrder.values();
-        if (sortOrderIdx >= 0 && te.getGuiSortMode() < orders.length) {
+        if (sortOrderIdx >= 0 && sortOrderIdx < orders.length) {
             view.setSortOrder(orders[sortOrderIdx], (sortMode & 1) != 0);
         }
 


### PR DESCRIPTION
Fixes an issue where the last 3 sort options of the inventory panel (mod id desc, quantity asc, quantity desc) would not persist after closing and opening the inventory panel ui