### PR TITLE
Fix inventory panel showing wrong counts for GT chests and JABBA barrels

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,6 +16,7 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-812-GTNH:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.261:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Jabba:1.5.18:dev') {transitive = false}
     compileOnly("com.github.GTNewHorizons:ModularUI2:2.3.37-1.7.10:dev") {transitive = false}
     compileOnly('com.github.GTNewHorizons:Railcraft:9.17.17:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:StorageDrawers:2.2.9-GTNH:api') {transitive = false}

--- a/src/main/java/crazypants/enderio/conduit/item/NetworkedInventory.java
+++ b/src/main/java/crazypants/enderio/conduit/item/NetworkedInventory.java
@@ -425,6 +425,13 @@ public class NetworkedInventory {
         return inv;
     }
 
+    public TileEntity getConnectedTileEntity() {
+        if (isInvalid()) {
+            updateInventory();
+        }
+        return connectedTileEntity;
+    }
+
     public ISidedInventory getInventoryRecheck() {
         if (isInvalid()) {
             updateInventory();

--- a/src/main/java/crazypants/enderio/machine/invpanel/server/GregTechChestInventory.java
+++ b/src/main/java/crazypants/enderio/machine/invpanel/server/GregTechChestInventory.java
@@ -1,0 +1,68 @@
+package crazypants.enderio.machine.invpanel.server;
+
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+
+import crazypants.enderio.conduit.item.NetworkedInventory;
+import gregtech.common.tileentities.storage.MTEDigitalChestBase;
+
+class GregTechChestInventory extends AbstractInventory {
+
+    final NetworkedInventory ni;
+    final MTEDigitalChestBase chest;
+
+    GregTechChestInventory(NetworkedInventory ni, MTEDigitalChestBase chest) {
+        this.ni = ni;
+        this.chest = chest;
+        this.slotKeys = new SlotKey[1];
+    }
+
+    private int getTotalCount() {
+        int count = chest.getItemCount();
+        ItemStack extra = chest.getExtraItemStack();
+        if (extra != null) {
+            count += extra.stackSize;
+        }
+        return count;
+    }
+
+    @Override
+    int scanInventory(InventoryDatabaseServer db) {
+        ItemStack storedItem = chest.getItemStack();
+        int totalCount = getTotalCount();
+        if (storedItem == null || totalCount <= 0) {
+            setEmpty(db);
+            return 0;
+        }
+        updateSlot(db, 0, storedItem, totalCount);
+        return 1;
+    }
+
+    @Override
+    int extractItem(InventoryDatabaseServer db, ItemEntry entry, int slot, int count) {
+        ISidedInventory inv = ni.getInventoryRecheck();
+        int side = ni.getInventorySide();
+        int[] slotIndices = inv.getAccessibleSlotsFromSide(side);
+        if (slotIndices == null) {
+            return 0;
+        }
+        for (int slotIndex : slotIndices) {
+            ItemStack stack = inv.getStackInSlot(slotIndex);
+            if (stack == null || !inv.canExtractItem(slotIndex, stack, side)) {
+                continue;
+            }
+            if (db.lookupItem(stack, entry, false) != entry) {
+                continue;
+            }
+            int available = stack.stackSize;
+            if (count > available) {
+                count = available;
+            }
+            ni.itemExtracted(slotIndex, count);
+            int remaining = getTotalCount();
+            updateCount(db, 0, entry, remaining);
+            return count;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/crazypants/enderio/machine/invpanel/server/InventoryFactory.java
+++ b/src/main/java/crazypants/enderio/machine/invpanel/server/InventoryFactory.java
@@ -3,11 +3,15 @@ package crazypants.enderio.machine.invpanel.server;
 import java.util.ArrayList;
 
 import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.tileentity.TileEntity;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 
 import cpw.mods.fml.common.Loader;
 import crazypants.enderio.conduit.item.NetworkedInventory;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.common.tileentities.storage.MTEDigitalChestBase;
+import mcp.mobius.betterbarrels.common.blocks.TileEntityBarrel;
 import powercrystals.minefactoryreloaded.api.IDeepStorageUnit;
 
 public abstract class InventoryFactory {
@@ -19,6 +23,12 @@ public abstract class InventoryFactory {
         factories.add(new DSUFactory());
         if (Loader.isModLoaded("StorageDrawers")) {
             factories.add(new DrawerFactory());
+        }
+        if (Loader.isModLoaded("JABBA")) {
+            factories.add(new JabbaFactory());
+        }
+        if (Loader.isModLoaded("gregtech")) {
+            factories.add(new GregTechFactory());
         }
     }
 
@@ -39,8 +49,12 @@ public abstract class InventoryFactory {
         @Override
         AbstractInventory create(NetworkedInventory ni) {
             ISidedInventory inv = ni.getInventory();
-            if (inv instanceof IDeepStorageUnit) {
-                return new DSUInventory((IDeepStorageUnit) inv);
+            if (inv instanceof IDeepStorageUnit dsu) {
+                return new DSUInventory(dsu);
+            }
+            TileEntity te = ni.getConnectedTileEntity();
+            if (te instanceof IDeepStorageUnit dsu) {
+                return new DSUInventory(dsu);
             }
             return null;
         }
@@ -51,8 +65,48 @@ public abstract class InventoryFactory {
         @Override
         AbstractInventory create(NetworkedInventory ni) {
             ISidedInventory inv = ni.getInventory();
-            if (inv instanceof IDrawerGroup) {
-                return new DrawerGroupInventory((IDrawerGroup) inv);
+            if (inv instanceof IDrawerGroup dg) {
+                return new DrawerGroupInventory(dg);
+            }
+            TileEntity te = ni.getConnectedTileEntity();
+            if (te instanceof IDrawerGroup dg) {
+                return new DrawerGroupInventory(dg);
+            }
+            return null;
+        }
+    }
+
+    static class JabbaFactory extends InventoryFactory {
+
+        @Override
+        AbstractInventory create(NetworkedInventory ni) {
+            ISidedInventory inv = ni.getInventory();
+            if (inv instanceof TileEntityBarrel barrel) {
+                return new JabbaBarrelInventory(barrel);
+            }
+            TileEntity te = ni.getConnectedTileEntity();
+            if (te instanceof TileEntityBarrel barrel) {
+                return new JabbaBarrelInventory(barrel);
+            }
+            return null;
+        }
+    }
+
+    static class GregTechFactory extends InventoryFactory {
+
+        @Override
+        AbstractInventory create(NetworkedInventory ni) {
+            ISidedInventory inv = ni.getInventory();
+            if (inv instanceof IGregTechTileEntity gte) {
+                if (gte.getMetaTileEntity() instanceof MTEDigitalChestBase chest) {
+                    return new GregTechChestInventory(ni, chest);
+                }
+            }
+            TileEntity te = ni.getConnectedTileEntity();
+            if (te instanceof IGregTechTileEntity gte) {
+                if (gte.getMetaTileEntity() instanceof MTEDigitalChestBase chest) {
+                    return new GregTechChestInventory(ni, chest);
+                }
             }
             return null;
         }

--- a/src/main/java/crazypants/enderio/machine/invpanel/server/JabbaBarrelInventory.java
+++ b/src/main/java/crazypants/enderio/machine/invpanel/server/JabbaBarrelInventory.java
@@ -1,0 +1,45 @@
+package crazypants.enderio.machine.invpanel.server;
+
+import net.minecraft.item.ItemStack;
+
+import mcp.mobius.betterbarrels.common.blocks.TileEntityBarrel;
+
+class JabbaBarrelInventory extends AbstractInventory {
+
+    final TileEntityBarrel barrel;
+
+    JabbaBarrelInventory(TileEntityBarrel barrel) {
+        this.barrel = barrel;
+        this.slotKeys = new SlotKey[1];
+    }
+
+    @Override
+    int scanInventory(InventoryDatabaseServer db) {
+        ItemStack stored = barrel.getStoredItemType();
+        if (stored == null || stored.stackSize <= 0) {
+            setEmpty(db);
+            return 0;
+        }
+        updateSlot(db, 0, stored, stored.stackSize);
+        return 1;
+    }
+
+    @Override
+    int extractItem(InventoryDatabaseServer db, ItemEntry entry, int slot, int count) {
+        ItemStack stored = barrel.getStoredItemType();
+        if (stored == null || stored.stackSize <= 0) {
+            return 0;
+        }
+        if (db.lookupItem(stored, entry, false) != entry) {
+            return 0;
+        }
+        int available = stored.stackSize;
+        if (count > available) {
+            count = available;
+        }
+        int remaining = available - count;
+        barrel.setStoredItemCount(remaining);
+        updateCount(db, 0, entry, remaining);
+        return count;
+    }
+}

--- a/src/main/java/crazypants/enderio/machine/invpanel/server/NormalInventory.java
+++ b/src/main/java/crazypants/enderio/machine/invpanel/server/NormalInventory.java
@@ -16,6 +16,10 @@ class NormalInventory extends AbstractInventory {
     @Override
     int scanInventory(InventoryDatabaseServer db) {
         ISidedInventory inv = ni.getInventoryRecheck();
+        if (inv == null) {
+            setEmpty(db);
+            return 0;
+        }
         int side = ni.getInventorySide();
         int[] slotIndices = inv.getAccessibleSlotsFromSide(side);
         if (slotIndices == null || slotIndices.length == 0) {
@@ -40,6 +44,9 @@ class NormalInventory extends AbstractInventory {
     @Override
     public int extractItem(InventoryDatabaseServer db, ItemEntry entry, int slot, int count) {
         ISidedInventory inv = ni.getInventoryRecheck();
+        if (inv == null) {
+            return 0;
+        }
         int side = ni.getInventorySide();
         int[] slotIndices = inv.getAccessibleSlotsFromSide(side);
         if (slotIndices == null || slot >= slotIndices.length) {


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24159

The inventory panel showed incorrect item counts for GregTech digital, quantum, and super chests, as well as JABBA barrels. Dedicated inventory handlers have been added for both. Also fixes a pre-existing NPE crash in NormalInventory when a connected inventory becomes invalid.