### PR TITLE
Remove space suit from end steel armor

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,7 +15,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Backhand:1.8.4:dev") { transitive = false }
     compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-812-GTNH:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.261:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.576:dev') {transitive = false}
     compileOnly("com.github.GTNewHorizons:ModularUI2:2.3.37-1.7.10:dev") {transitive = false}
     compileOnly('com.github.GTNewHorizons:Railcraft:9.17.17:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:StorageDrawers:2.2.9-GTNH:api') {transitive = false}

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
@@ -85,6 +85,6 @@ public class ItemEndSteelArmor extends ItemDarkSteelArmor implements IEndSteelIt
     @Optional.Method(modid = "gregtech_nh")
     @Override
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
-        return hazard != Hazard.SPACE;
+        return Hazard.STANDARD_HAZARDS.contains(hazard);
     }
 }

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemEndSteelArmor.java
@@ -85,6 +85,6 @@ public class ItemEndSteelArmor extends ItemDarkSteelArmor implements IEndSteelIt
     @Optional.Method(modid = "gregtech_nh")
     @Override
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
-        return true;
+        return hazard != Hazard.SPACE;
     }
 }


### PR DESCRIPTION
This was just a regression due to spacesuit being moved to the hazard system, while most hazard implementations used to be just "return true".

Sister GT pr: https://github.com/GTNewHorizons/GT5-Unofficial/pull/6925

Draft, want to change something that needs a gt5 release