### PR TITLE
Add a dimension blocklist to the Dark Steel armor glider

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -2,6 +2,7 @@ package crazypants.enderio.config;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 
@@ -279,6 +280,8 @@ public final class Config {
     public static double darkSteelGliderHorizontalSpeed = 0.03;
     public static double darkSteelGliderVerticalSpeed = -0.05;
     public static double darkSteelGliderVerticalSpeedSprinting = -0.15;
+    public static int[] darkSteelGliderDimensionBlocklist = {};
+    public static HashSet<Integer> darkSteelGliderDimensionBlocklistHash = new HashSet<>();
 
     public static int darkSteelGogglesOfRevealingCost = 10;
 
@@ -1575,6 +1578,11 @@ public final class Config {
                         darkSteelGliderVerticalSpeedSprinting,
                         "Rate of altitude loss when sprinting and gliding.")
                 .getDouble(darkSteelGliderVerticalSpeedSprinting);
+        darkSteelGliderDimensionBlocklist = config.get(
+                sectionDarkSteel.name,
+                "darkSteelGliderDimensionBlocklist",
+                darkSteelGliderDimensionBlocklist,
+                "List of numeric IDs of dimensions in which the 'Glider' upgrade will not work.").getIntList();
 
         darkSteelSoundLocatorCost = config.get(
                 sectionDarkSteel.name,
@@ -2996,6 +3004,11 @@ public final class Config {
             if (hoe != null) {
                 farmHoes.add(hoe);
             }
+        }
+
+        darkSteelGliderDimensionBlocklistHash.clear();
+        for (int dimId : darkSteelGliderDimensionBlocklist) {
+            darkSteelGliderDimensionBlocklistHash.add(dimId);
         }
     }
 

--- a/src/main/java/crazypants/enderio/item/KeyTracker.java
+++ b/src/main/java/crazypants/enderio/item/KeyTracker.java
@@ -329,10 +329,13 @@ public class KeyTracker {
 
     private void handleGlide() {
         EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-        if (glideKey.isPressed() && DarkSteelController.instance.isGliderUpgradeEquipped(player)
-                && (DarkSteelController.instance.isGlideActive(player)
-                        || DarkSteelController.instance.canActivateGlide(player))) {
-            toggleDarkSteelController(Type.GLIDE, "darksteel.upgrade.glider");
+        if (glideKey.isPressed() && DarkSteelController.instance.isGliderUpgradeEquipped(player)) {
+            if ((DarkSteelController.instance.isGlideActive(player)
+                    || DarkSteelController.instance.canActivateGlide(player))) {
+                toggleDarkSteelController(Type.GLIDE, "darksteel.upgrade.glider");
+            } else if (!DarkSteelController.instance.isGlideAllowedInDimension(player)) {
+                ChatUtil.sendNoSpamClientUnloc(EnderIO.lang, "darksteel.upgrade.glider.blocklisted");
+            }
         }
     }
 

--- a/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
@@ -23,6 +23,7 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovementInput;
 import net.minecraftforge.client.event.RenderPlayerEvent;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 
 import org.lwjgl.opengl.GL11;
@@ -161,8 +162,12 @@ public class DarkSteelController {
         return isActive(player, Type.GLIDE);
     }
 
+    public boolean isGlideAllowedInDimension(EntityPlayer player) {
+        return !Config.darkSteelGliderDimensionBlocklistHash.contains(player.dimension);
+    }
+
     public boolean canActivateGlide(EntityPlayer player) {
-        return !EtFuturumCompat.isElytraFlying(player);
+        return !EtFuturumCompat.isElytraFlying(player) && isGlideAllowedInDimension(player);
     }
 
     public boolean isSpeedActive(EntityPlayer player) {
@@ -196,6 +201,15 @@ public class DarkSteelController {
             updateSwim(player);
 
             updateSolar(player);
+        }
+    }
+
+    @SubscribeEvent
+    public void onJoinDimension(EntityJoinWorldEvent event) {
+        if (event.entity instanceof EntityPlayer player) {
+            if (!isGlideAllowedInDimension(player)) {
+                setActive(player, Type.GLIDE, false);
+            }
         }
     }
 

--- a/src/main/resources/assets/enderio/lang/de_DE.lang
+++ b/src/main/resources/assets/enderio/lang/de_DE.lang
@@ -871,6 +871,7 @@ enderio.darksteel.upgrade.glider.name=Gleiter
 enderio.darksteel.upgrade.glider.tooltip.detailed.line1=Ermöglicht Gleiten
 enderio.darksteel.upgrade.glider.enabled=Gleiter Aktiv
 enderio.darksteel.upgrade.glider.disabled=Gleiter Inaktiv
+enderio.darksteel.upgrade.glider.blocklisted=Der Gleiter scheint nicht in dieser Dimension zu funktionieren...
 
 enderio.darksteel.upgrade.sound.name=Schalldetektor
 enderio.darksteel.upgrade.sound.tooltip.detailed.line1=Zeigt die Position von

--- a/src/main/resources/assets/enderio/lang/en_US.lang
+++ b/src/main/resources/assets/enderio/lang/en_US.lang
@@ -969,6 +969,7 @@ enderio.darksteel.upgrade.glider.name=Glider
 enderio.darksteel.upgrade.glider.tooltip.detailed.line1=Enables gliding
 enderio.darksteel.upgrade.glider.enabled=Glider Active
 enderio.darksteel.upgrade.glider.disabled=Glider Disabled
+enderio.darksteel.upgrade.glider.blocklisted=The Glider does not seem to work in this dimension...
 
 enderio.darksteel.upgrade.sound.name=Sound Locator
 enderio.darksteel.upgrade.sound.tooltip.detailed.line1=Displays the location of


### PR DESCRIPTION
## Summary
The OpenBlocks Glider has a [dimension blocklist](https://github.com/GTNewHorizons/OpenBlocks/blob/1825aea308c1d163f84ec9770f9d1f3de1bfcdc0/src/main/java/openblocks/common/item/ItemHangGlider.java#L84-L89). I noticed this trying to use it on Mars. I also found out the the Dark Steel armor glider does not have such a blocklist and will work everywhere, which I think it shouldn't.

Small note for the implementation: I needed to listen to `EntityJoinEvent` to be able to deactivate the glider if the player joins a dimension that is blocklisted.

The default blocklist is empty since the glider should work in all vanilla dimensions. I'll make a PR to config repo with GTNH-relevant dimensions if this change is accepted here.

<img width="854" height="480" alt="2026-07-23_21 38 32" src="https://github.com/user-attachments/assets/690a9ddb-7a7f-46fe-827d-eb79a56de159" />
(just for testing I blocklisted the Nether here)

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
