### PR TITLE
fix: billboard toward renderViewEntity

### DIFF
--- a/src/main/java/crazypants/enderio/enderface/EnderIoRenderer.java
+++ b/src/main/java/crazypants/enderio/enderface/EnderIoRenderer.java
@@ -46,7 +46,10 @@ public class EnderIoRenderer extends TileEntitySpecialRenderer implements IItemR
     public void renderTileEntityAt(TileEntity te, double x, double y, double z, float f) {
 
         EntityLivingBase entityPlayer = Minecraft.getMinecraft().thePlayer;
-        Matrix4d lookMat = RenderUtil.createBillboardMatrix(te, entityPlayer);
+        EntityLivingBase viewEntity = Minecraft.getMinecraft().renderViewEntity != null
+                ? Minecraft.getMinecraft().renderViewEntity
+                : entityPlayer;
+        Matrix4d lookMat = RenderUtil.createBillboardMatrix(te, viewEntity);
 
         int brightness = RenderUtil.setTesselatorBrightness(entityPlayer.worldObj, te.xCoord, te.yCoord, te.zCoord);
         render(x, y, z, lookMat, brightness);


### PR DESCRIPTION
## Summary
Freecam compat - billboard toward renderViewEntity


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
