### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/gas/AbstractGasConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/gas/AbstractGasConduit.java
@@ -184,8 +184,8 @@ public abstract class AbstractGasConduit extends AbstractConduit implements IGas
             String key = "extRM." + dir.name();
             if (nbtRoot.hasKey(key)) {
                 short ord = nbtRoot.getShort(key);
-                if (ord >= 0 && ord < RedstoneControlMode.values().length) {
-                    extractionModes.put(dir, RedstoneControlMode.values()[ord]);
+                if (ord >= 0 && ord < RedstoneControlMode.VALUES.length) {
+                    extractionModes.put(dir, RedstoneControlMode.VALUES[ord]);
                 }
             }
             key = "extSC." + dir.name();

--- a/src/main/java/crazypants/enderio/conduit/item/ItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/item/ItemConduit.java
@@ -152,7 +152,7 @@ public class ItemConduit extends AbstractConduit implements IItemConduit {
     @Override
     protected void readTypeSettings(ForgeDirection dir, NBTTagCompound dataRoot) {
         setExtractionSignalColor(dir, DyeColor.VALUES[dataRoot.getShort("extractionSignalColor")]);
-        setExtractionRedstoneMode(RedstoneControlMode.values()[dataRoot.getShort("extractionRedstoneMode")], dir);
+        setExtractionRedstoneMode(RedstoneControlMode.VALUES[dataRoot.getShort("extractionRedstoneMode")], dir);
         setInputColor(dir, DyeColor.VALUES[dataRoot.getShort("inputColor")]);
         setOutputColor(dir, DyeColor.VALUES[dataRoot.getShort("outputColor")]);
         setSelfFeedEnabled(dir, dataRoot.getBoolean("selfFeed"));
@@ -837,8 +837,8 @@ public class ItemConduit extends AbstractConduit implements IItemConduit {
             key = "extRM." + dir.name();
             if (nbtRoot.hasKey(key)) {
                 short ord = nbtRoot.getShort(key);
-                if (ord >= 0 && ord < RedstoneControlMode.values().length) {
-                    extractionModes.put(dir, RedstoneControlMode.values()[ord]);
+                if (ord >= 0 && ord < RedstoneControlMode.VALUES.length) {
+                    extractionModes.put(dir, RedstoneControlMode.VALUES[ord]);
                 }
             }
             key = "extSC." + dir.name();

--- a/src/main/java/crazypants/enderio/conduit/liquid/AbstractLiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/AbstractLiquidConduit.java
@@ -203,7 +203,7 @@ public abstract class AbstractLiquidConduit extends AbstractConduit implements I
     @Override
     protected void readTypeSettings(ForgeDirection dir, NBTTagCompound dataRoot) {
         setExtractionSignalColor(dir, DyeColor.VALUES[dataRoot.getShort("extractionSignalColor")]);
-        setExtractionRedstoneMode(RedstoneControlMode.values()[dataRoot.getShort("extractionRedstoneMode")], dir);
+        setExtractionRedstoneMode(RedstoneControlMode.VALUES[dataRoot.getShort("extractionRedstoneMode")], dir);
     }
 
     @Override
@@ -239,8 +239,8 @@ public abstract class AbstractLiquidConduit extends AbstractConduit implements I
             String key = "extRM." + dir.name();
             if (nbtRoot.hasKey(key)) {
                 short ord = nbtRoot.getShort(key);
-                if (ord >= 0 && ord < RedstoneControlMode.values().length) {
-                    extractionModes.put(dir, RedstoneControlMode.values()[ord]);
+                if (ord >= 0 && ord < RedstoneControlMode.VALUES.length) {
+                    extractionModes.put(dir, RedstoneControlMode.VALUES[ord]);
                 }
             }
             key = "extSC." + dir.name();

--- a/src/main/java/crazypants/enderio/conduit/packet/PacketExtractMode.java
+++ b/src/main/java/crazypants/enderio/conduit/packet/PacketExtractMode.java
@@ -40,7 +40,7 @@ public class PacketExtractMode extends AbstractConduitPacket<IExtractor>
     public void fromBytes(ByteBuf buf) {
         super.fromBytes(buf);
         dir = ForgeDirections.DIRECTIONS[buf.readShort()];
-        mode = RedstoneControlMode.values()[buf.readShort()];
+        mode = RedstoneControlMode.VALUES[buf.readShort()];
         color = DyeColor.VALUES[buf.readShort()];
     }
 

--- a/src/main/java/crazypants/enderio/conduit/power/PowerConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/power/PowerConduit.java
@@ -209,7 +209,7 @@ public class PowerConduit extends AbstractConduit implements IPowerConduit {
     @Override
     protected void readTypeSettings(ForgeDirection dir, NBTTagCompound dataRoot) {
         setExtractionSignalColor(dir, DyeColor.VALUES[dataRoot.getShort("extractionSignalColor")]);
-        setExtractionRedstoneMode(RedstoneControlMode.values()[dataRoot.getShort("extractionRedstoneMode")], dir);
+        setExtractionRedstoneMode(RedstoneControlMode.VALUES[dataRoot.getShort("extractionRedstoneMode")], dir);
     }
 
     @Override
@@ -253,8 +253,8 @@ public class PowerConduit extends AbstractConduit implements IPowerConduit {
             String key = "pRsMode." + dir.name();
             if (nbtRoot.hasKey(key)) {
                 short ord = nbtRoot.getShort(key);
-                if (ord >= 0 && ord < RedstoneControlMode.values().length) {
-                    rsModes.put(dir, RedstoneControlMode.values()[ord]);
+                if (ord >= 0 && ord < RedstoneControlMode.VALUES.length) {
+                    rsModes.put(dir, RedstoneControlMode.VALUES[ord]);
                 }
             }
             key = "pRsCol." + dir.name();

--- a/src/main/java/crazypants/enderio/item/skull/BlockEndermanSkull.java
+++ b/src/main/java/crazypants/enderio/item/skull/BlockEndermanSkull.java
@@ -29,6 +29,7 @@ public class BlockEndermanSkull extends BlockEio implements IInfusionStabiliser 
         TORMENTED("tormented", false),
         REANIMATED_TORMENTED("reanimatedTormented", true);
 
+        public static final SkullType[] VALUES = values();
         final String name;
         final boolean showEyes;
 
@@ -74,8 +75,8 @@ public class BlockEndermanSkull extends BlockEio implements IInfusionStabiliser 
     public IIcon getIcon(int side, int meta) {
         ForgeDirection orint = ForgeDirection.getOrientation(side);
         if (orint == ForgeDirection.NORTH) {
-            meta = MathHelper.clamp_int(meta, 0, SkullType.values().length - 1);
-            return SkullType.values()[meta].showEyes ? frontIconEyes : frontIcon;
+            meta = MathHelper.clamp_int(meta, 0, SkullType.VALUES.length - 1);
+            return SkullType.VALUES[meta].showEyes ? frontIconEyes : frontIcon;
         }
         if (orint == ForgeDirection.UP || orint == ForgeDirection.DOWN || orint == ForgeDirection.SOUTH) {
             return topIcon;

--- a/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
@@ -472,10 +472,10 @@ public abstract class AbstractMachineEntity extends TileEntityEio
         }
 
         int rsContr = nbtRoot.getInteger("redstoneControlMode");
-        if (rsContr < 0 || rsContr >= RedstoneControlMode.values().length) {
+        if (rsContr < 0 || rsContr >= RedstoneControlMode.VALUES.length) {
             rsContr = 0;
         }
-        redstoneControlMode = RedstoneControlMode.values()[rsContr];
+        redstoneControlMode = RedstoneControlMode.VALUES[rsContr];
 
         if (nbtRoot.hasKey("hasFaces")) {
             for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {

--- a/src/main/java/crazypants/enderio/machine/PacketRedstoneMode.java
+++ b/src/main/java/crazypants/enderio/machine/PacketRedstoneMode.java
@@ -46,7 +46,7 @@ public class PacketRedstoneMode implements IMessage, IMessageHandler<PacketRedst
         y = buf.readInt();
         z = buf.readInt();
         short ordinal = buf.readShort();
-        mode = RedstoneControlMode.values()[ordinal];
+        mode = RedstoneControlMode.VALUES[ordinal];
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/RedstoneControlMode.java
+++ b/src/main/java/crazypants/enderio/machine/RedstoneControlMode.java
@@ -19,6 +19,8 @@ public enum RedstoneControlMode implements ICycleEnum {
     OFF(IconEIO.REDSTONE_MODE_WITHOUT_SIGNAL),
     NEVER(IconEIO.REDSTONE_MODE_NEVER);
 
+    public static final RedstoneControlMode[] VALUES = values();
+
     private final IWidgetIcon icon;
 
     RedstoneControlMode(IWidgetIcon icon) {
@@ -63,20 +65,20 @@ public enum RedstoneControlMode implements ICycleEnum {
 
     public RedstoneControlMode next() {
         int ord = ordinal();
-        if (ord == values().length - 1) {
+        if (ord == VALUES.length - 1) {
             ord = 0;
         } else {
             ord++;
         }
-        return values()[ord];
+        return VALUES[ord];
     }
 
     public RedstoneControlMode previous() {
         int ord = ordinal();
         ord--;
         if (ord < 0) {
-            ord = values().length - 1;
+            ord = VALUES.length - 1;
         }
-        return values()[ord];
+        return VALUES[ord];
     }
 }

--- a/src/main/java/crazypants/enderio/machine/buffer/BlockItemBuffer.java
+++ b/src/main/java/crazypants/enderio/machine/buffer/BlockItemBuffer.java
@@ -26,6 +26,7 @@ public class BlockItemBuffer extends ItemBlockWithMetadata {
         OMNI(true, true, false),
         CREATIVE(true, true, true);
 
+        public static final Type[] VALUES = values();
         final boolean hasInventory;
         final boolean hasPower;
         final boolean isCreative;
@@ -60,14 +61,14 @@ public class BlockItemBuffer extends ItemBlockWithMetadata {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item item, CreativeTabs tab, List<ItemStack> list) {
-        for (Type type : Type.values()) {
+        for (Type type : Type.VALUES) {
             list.add(new ItemStack(item, 1, type.ordinal()));
         }
     }
 
     @Override
     public String getUnlocalizedName(ItemStack stack) {
-        return Type.values()[stack.getItemDamage()].getUnlocalizedName();
+        return Type.VALUES[stack.getItemDamage()].getUnlocalizedName();
     }
 
     @Override
@@ -78,7 +79,7 @@ public class BlockItemBuffer extends ItemBlockWithMetadata {
             TileEntity te = world.getTileEntity(x, y, z);
             if (te instanceof TileBuffer) {
                 TileBuffer buffer = ((TileBuffer) te);
-                Type t = Type.values()[metadata];
+                Type t = Type.VALUES[metadata];
                 buffer.setHasInventory(t.hasInventory);
                 buffer.setHasPower(t.hasPower);
                 buffer.setCreative(t.isCreative);

--- a/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
@@ -882,12 +882,12 @@ public class TileCapBank extends TileEntityEio
         }
 
         if (nbtRoot.hasKey("inputControlMode")) {
-            inputControlMode = RedstoneControlMode.values()[nbtRoot.getShort("inputControlMode")];
+            inputControlMode = RedstoneControlMode.VALUES[nbtRoot.getShort("inputControlMode")];
         } else {
             inputControlMode = RedstoneControlMode.IGNORE;
         }
         if (nbtRoot.hasKey("outputControlMode")) {
-            outputControlMode = RedstoneControlMode.values()[nbtRoot.getShort("outputControlMode")];
+            outputControlMode = RedstoneControlMode.VALUES[nbtRoot.getShort("outputControlMode")];
         } else {
             outputControlMode = RedstoneControlMode.IGNORE;
         }

--- a/src/main/java/crazypants/enderio/machine/capbank/network/NetworkState.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/network/NetworkState.java
@@ -115,8 +115,8 @@ public class NetworkState {
                 buf.readInt(),
                 buf.readInt(),
                 buf.readInt(),
-                RedstoneControlMode.values()[buf.readShort()],
-                RedstoneControlMode.values()[buf.readShort()],
+                RedstoneControlMode.VALUES[buf.readShort()],
+                RedstoneControlMode.VALUES[buf.readShort()],
                 buf.readBoolean() ? BlockCoord.readFromBuf(buf) : null,
                 buf.readFloat(),
                 buf.readFloat());

--- a/src/main/java/crazypants/enderio/machine/capbank/packet/PacketGuiChange.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/packet/PacketGuiChange.java
@@ -39,8 +39,8 @@ public class PacketGuiChange extends PacketCapBank<PacketGuiChange, IMessage> {
         super.fromBytes(buf);
         maxSend = buf.readInt();
         maxRec = buf.readInt();
-        inputMode = RedstoneControlMode.values()[buf.readShort()];
-        outputMode = RedstoneControlMode.values()[buf.readShort()];
+        inputMode = RedstoneControlMode.VALUES[buf.readShort()];
+        outputMode = RedstoneControlMode.VALUES[buf.readShort()];
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/machine/hypercube/TileHyperCube.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/TileHyperCube.java
@@ -826,7 +826,7 @@ public class TileHyperCube extends TileEntityEio
         recieveBuffer.readFromNBT(nbtRoot);
 
         if (nbtRoot.hasKey("rsMode")) {
-            redstoneControlMode = RedstoneControlMode.values()[nbtRoot.getShort("rsMode")];
+            redstoneControlMode = RedstoneControlMode.VALUES[nbtRoot.getShort("rsMode")];
         } else {
             redstoneControlMode = RedstoneControlMode.IGNORE;
         }

--- a/src/main/java/crazypants/enderio/machine/light/BlockItemElectricLight.java
+++ b/src/main/java/crazypants/enderio/machine/light/BlockItemElectricLight.java
@@ -31,6 +31,7 @@ public class BlockItemElectricLight extends ItemBlockWithMetadata implements IRe
         WIRELESS("item.itemWirelessLight", false, true, true),
         WIRELESS_INV("item.itemWirelessLightInverted", true, true, true);
 
+        public static final Type[] VALUES = values();
         final String unlocName;
         final boolean isInverted;
         final boolean isPowered;
@@ -52,14 +53,14 @@ public class BlockItemElectricLight extends ItemBlockWithMetadata implements IRe
     @Override
     public String getUnlocalizedName(ItemStack par1ItemStack) {
         int meta = par1ItemStack.getItemDamage();
-        meta = MathHelper.clamp_int(meta, 0, Type.values().length - 1);
-        return Type.values()[meta].unlocName;
+        meta = MathHelper.clamp_int(meta, 0, Type.VALUES.length - 1);
+        return Type.VALUES[meta].unlocName;
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List<ItemStack> par3List) {
-        for (Type type : Type.values()) {
+        for (Type type : Type.VALUES) {
             par3List.add(new ItemStack(this, 1, type.ordinal()));
         }
     }
@@ -76,7 +77,7 @@ public class BlockItemElectricLight extends ItemBlockWithMetadata implements IRe
             if (te instanceof TileElectricLight) {
                 TileElectricLight el = ((TileElectricLight) te);
                 el.setFace(onFace);
-                Type t = Type.values()[metadata];
+                Type t = Type.VALUES[metadata];
                 el.setInverted(t.isInverted);
                 el.setRequiresPower(t.isPowered);
                 el.setWireless(t.isWireless);

--- a/src/main/java/crazypants/enderio/machine/vacuum/TileVacuumChest.java
+++ b/src/main/java/crazypants/enderio/machine/vacuum/TileVacuumChest.java
@@ -378,10 +378,10 @@ public class TileVacuumChest extends TileEntityEio
         }
 
         int rsContr = nbtRoot.getInteger("redstoneControlMode");
-        if (rsContr < 0 || rsContr >= RedstoneControlMode.values().length) {
+        if (rsContr < 0 || rsContr >= RedstoneControlMode.VALUES.length) {
             rsContr = 0;
         }
-        redstoneControlMode = RedstoneControlMode.values()[rsContr];
+        redstoneControlMode = RedstoneControlMode.VALUES[rsContr];
     }
 
     @Override

--- a/src/main/java/crazypants/enderio/material/FrankenSkull.java
+++ b/src/main/java/crazypants/enderio/material/FrankenSkull.java
@@ -10,6 +10,7 @@ public enum FrankenSkull {
     SKELETAL_CONTRACTOR("skullSkeletalContractor", "enderio:skullSkeletalContractor", false),
     GUARDIAN_DIODE("skullGuardianDiode", "enderio:skullGuardianDiode", false);
 
+    public static final FrankenSkull[] VALUES = values();
     public final String unlocalisedName;
     public final String iconKey;
     public final boolean isAnimated;

--- a/src/main/java/crazypants/enderio/material/ItemFrankenSkull.java
+++ b/src/main/java/crazypants/enderio/material/ItemFrankenSkull.java
@@ -30,7 +30,7 @@ public class ItemFrankenSkull extends Item {
         setMaxDamage(0);
         setCreativeTab(EnderIOTab.tabEnderIO);
         setUnlocalizedName(ModObject.itemFrankenSkull.unlocalisedName);
-        icons = new IIcon[FrankenSkull.values().length];
+        icons = new IIcon[FrankenSkull.VALUES.length];
     }
 
     private void init() {
@@ -48,20 +48,20 @@ public class ItemFrankenSkull extends Item {
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister IIconRegister) {
         for (int i = 0; i < icons.length; i++) {
-            icons[i] = IIconRegister.registerIcon(FrankenSkull.values()[i].iconKey);
+            icons[i] = IIconRegister.registerIcon(FrankenSkull.VALUES[i].iconKey);
         }
     }
 
     @Override
     public String getUnlocalizedName(ItemStack par1ItemStack) {
-        int i = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, FrankenSkull.values().length - 1);
-        return FrankenSkull.values()[i].unlocalisedName;
+        int i = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, FrankenSkull.VALUES.length - 1);
+        return FrankenSkull.VALUES[i].unlocalisedName;
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List<ItemStack> par3List) {
-        for (int j = 0; j < FrankenSkull.values().length; ++j) {
+        for (int j = 0; j < FrankenSkull.VALUES.length; ++j) {
             par3List.add(new ItemStack(par1, 1, j));
         }
     }
@@ -69,7 +69,7 @@ public class ItemFrankenSkull extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public boolean hasEffect(ItemStack par1ItemStack, int pass) {
-        int meta = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, FrankenSkull.values().length - 1);
-        return FrankenSkull.values()[meta].isAnimated;
+        int meta = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, FrankenSkull.VALUES.length - 1);
+        return FrankenSkull.VALUES[meta].isAnimated;
     }
 }

--- a/src/main/java/crazypants/enderio/material/ItemMachinePart.java
+++ b/src/main/java/crazypants/enderio/material/ItemMachinePart.java
@@ -31,7 +31,7 @@ public class ItemMachinePart extends Item {
         setCreativeTab(EnderIOTab.tabEnderIO);
         setUnlocalizedName(ModObject.itemMachinePart.unlocalisedName);
 
-        icons = new IIcon[MachinePart.values().length];
+        icons = new IIcon[MachinePart.VALUES.length];
     }
 
     private void init() {
@@ -41,29 +41,29 @@ public class ItemMachinePart extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage(int damage) {
-        damage = MathHelper.clamp_int(damage, 0, MachinePart.values().length - 1);
+        damage = MathHelper.clamp_int(damage, 0, MachinePart.VALUES.length - 1);
         return icons[damage];
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister IIconRegister) {
-        int numParts = MachinePart.values().length;
+        int numParts = MachinePart.VALUES.length;
         for (int i = 0; i < numParts; i++) {
-            icons[i] = IIconRegister.registerIcon(MachinePart.values()[i].iconKey);
+            icons[i] = IIconRegister.registerIcon(MachinePart.VALUES[i].iconKey);
         }
     }
 
     @Override
     public String getUnlocalizedName(ItemStack par1ItemStack) {
-        int i = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, MachinePart.values().length - 1);
-        return MachinePart.values()[i].unlocalisedName;
+        int i = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, MachinePart.VALUES.length - 1);
+        return MachinePart.VALUES[i].unlocalisedName;
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List<ItemStack> par3List) {
-        for (int j = 0; j < MachinePart.values().length; ++j) {
+        for (int j = 0; j < MachinePart.VALUES.length; ++j) {
             par3List.add(new ItemStack(par1, 1, j));
         }
     }

--- a/src/main/java/crazypants/enderio/material/MachinePart.java
+++ b/src/main/java/crazypants/enderio/material/MachinePart.java
@@ -13,6 +13,7 @@ public enum MachinePart {
     SOUL_MACHINE_CHASSIS("soulMachineChassi"),
     END_STEEL_MACHINE_CHASSIS("endSteelMachineChassi");
 
+    public static final MachinePart[] VALUES = values();
     public final String unlocalisedName;
     public final String iconKey;
     public final String oreDict;
@@ -24,7 +25,7 @@ public enum MachinePart {
     }
 
     public static void registerOres(Item item) {
-        for (MachinePart m : values()) {
+        for (MachinePart m : VALUES) {
             OreDictionary.registerOre(m.oreDict, new ItemStack(item, 1, m.ordinal()));
         }
     }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
