### PR TITLE
Fix client NPE when placing wireless powered lights on dedicated servers

### DIFF
--- a/src/main/java/crazypants/enderio/machine/wireless/WirelessChargedLocation.java
+++ b/src/main/java/crazypants/enderio/machine/wireless/WirelessChargedLocation.java
@@ -24,7 +24,10 @@ public class WirelessChargedLocation {
          * use (unless ~4B changes happen in between). Do this instead directly updating so that WirelessChargedLocation
          * can be used while the TileEntity is still in construction (or loading).
          */
-        this.lastChangeCount = EnderIO.proxy.wirelessChargerController.getChangeCount() - 1;
+        // The controller only exists on the server (created in FMLServerAboutToStartEvent), so it is null on
+        // clients connected to a dedicated server. Chargers are only queried server-side, so stay inert there.
+        WirelessChargerController wcc = EnderIO.proxy.wirelessChargerController;
+        this.lastChangeCount = wcc == null ? 0 : wcc.getChangeCount() - 1;
     }
 
     private void updateChargers() {
@@ -41,7 +44,8 @@ public class WirelessChargedLocation {
     }
 
     private void checkChangeCount() {
-        if (lastChangeCount != EnderIO.proxy.wirelessChargerController.getChangeCount()) {
+        WirelessChargerController wcc = EnderIO.proxy.wirelessChargerController;
+        if (wcc != null && lastChangeCount != wcc.getChangeCount()) {
             updateChargers();
         }
     }


### PR DESCRIPTION
## Summary

`EnderIO.proxy.wirelessChargerController` is only created in `FMLServerAboutToStartEvent`, which never fires on a client connected to a dedicated server. Placing a wireless powered light.

```
java.lang.NullPointerException: Cannot invoke "crazypants.enderio.machine.wireless.WirelessChargerController.getChangeCount()" because "crazypants.enderio.EnderIO.proxy.wirelessChargerController" is null
    at crazypants.enderio.machine.wireless.WirelessChargedLocation.<init>(WirelessChargedLocation.java:27)
    at crazypants.enderio.machine.light.TileElectricLight.setWireless(TileElectricLight.java:99)
    at crazypants.enderio.machine.light.BlockItemElectricLight.placeBlockAt(BlockItemElectricLight.java:82)
```

The chunk-sync path also makes worlds appear "corrupted": rejoining near an existing wireless light crashes the client on chunk load.

This PR guards the controller access so `WirelessChargedLocation` is inert client-side, matching the server-only design already used by `TileWirelessCharger` (`isRemote` guards).

Fixes the crash reported in GTNewHorizons/GT-New-Horizons-Modpack#26255.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge -> NO
