### PR TITLE
Update TileReservoir.java

### DIFF
--- a/src/main/java/crazypants/enderio/machine/reservoir/TileReservoir.java
+++ b/src/main/java/crazypants/enderio/machine/reservoir/TileReservoir.java
@@ -100,7 +100,7 @@ public class TileReservoir extends TileEntityEio implements IFluidHandler, ITank
 
             if (regenTank.isFull() && !tank.isFull()) {
                 ++ticksSinceFill;
-                if (ticksSinceFill >= 20) {
+                if (ticksSinceFill >= 10) {
                     ticksSinceFill = 0;
                     tank.fill(WATER_BUCKET, true);
                     tankDirty = true;

--- a/src/main/java/crazypants/enderio/machine/reservoir/TileReservoir.java
+++ b/src/main/java/crazypants/enderio/machine/reservoir/TileReservoir.java
@@ -100,7 +100,7 @@ public class TileReservoir extends TileEntityEio implements IFluidHandler, ITank
 
             if (regenTank.isFull() && !tank.isFull()) {
                 ++ticksSinceFill;
-                if (ticksSinceFill >= 5) {
+                if (ticksSinceFill >= 2) {
                     ticksSinceFill = 0;
                     tank.fill(WATER_BUCKET, true);
                     tankDirty = true;

--- a/src/main/java/crazypants/enderio/machine/reservoir/TileReservoir.java
+++ b/src/main/java/crazypants/enderio/machine/reservoir/TileReservoir.java
@@ -100,7 +100,7 @@ public class TileReservoir extends TileEntityEio implements IFluidHandler, ITank
 
             if (regenTank.isFull() && !tank.isFull()) {
                 ++ticksSinceFill;
-                if (ticksSinceFill >= 10) {
+                if (ticksSinceFill >= 5) {
                     ticksSinceFill = 0;
                     tank.fill(WATER_BUCKET, true);
                     tankDirty = true;


### PR DESCRIPTION
EnderIo currently did not refill its reservoir as fast as one vanilla water source does, which doesn't make sense as this was the feature it was imitating. Each source block now refills at the speed of 10Bps , slightly lower than the pump used to make it.

## Summary
Very small PR, Only one character was changed.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
