### PR TITLE
Respect recipe slot numbers when validating machine inputs

### DIFF
--- a/src/main/java/crazypants/enderio/machine/recipe/BasicManyToOneRecipe.java
+++ b/src/main/java/crazypants/enderio/machine/recipe/BasicManyToOneRecipe.java
@@ -31,12 +31,15 @@ public class BasicManyToOneRecipe implements IManyToOneRecipe {
     @Override
     public boolean isValidRecipeComponents(ItemStack... items) {
 
-        List<RecipeInput> inputs = new ArrayList<>(Arrays.asList(recipe.getInputs()));
-        for (ItemStack is : items) {
+        List<RecipeInput> inputs = new ArrayList<RecipeInput>(Arrays.asList(recipe.getInputs()));
+        for (int slot = 0; slot < items.length; slot++) {
+            ItemStack is = items[slot];
             if (is != null) {
                 RecipeInput remove = null;
                 for (RecipeInput ri : inputs) {
-                    if (ri.isInput(is)) {
+                    int riSlot = ri.getSlotNumber();
+                    // Match by item type and, if the recipe specifies a slot, also by slot index
+                    if (ri.isInput(is) && (riSlot == -1 || riSlot == slot)) {
                         remove = ri;
                         break;
                     }


### PR DESCRIPTION
## Summary
isValidRecipeComponents matched an item against any recipe ingredient of the same type and ignored the slot attribute from the recipe XML. In the Slice'N'Splice this let purified silicon into a slot reserved for another component, because a different recipe accepts silicon in a different slot. The outcome depended on the order items arrived in, which is why feeding red alloy plates before silicon happened to work.

Fixes the Z-Logic Controller autofill reported in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7242, closed as stale in 2022 and still present.

Alloy Smelter recipes define no slot attribute, so their ingredients keep slot -1 and remain slot agnostic.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge