### PR TITLE
Revert #231

### DIFF
--- a/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
@@ -571,13 +571,11 @@ public class DarkSteelController {
     private void updateNightvision(EntityPlayer player) {
         if (isNightVisionUpgradeOrEnchEquipped(player) && nightVisionActive) {
             player.addPotionEffect(new PotionEffect(Potion.nightVision.getId(), 210, 0, true));
-        } else if (!isNightVisionUpgradeOrEnchEquipped(player)
-                && player.getActivePotionEffect(Potion.nightVision) != null) {
-                    // Remove the effect when upgrade is not equipped (e.g. helmet removed), but do NOT
-                    // reset nightVisionActive — during dimension transitions the inventory is temporarily
-                    // empty, and resetting the flag would permanently disable night vision after portals.
-                    player.removePotionEffect(Potion.nightVision.getId());
-                }
+        }
+        if (!isNightVisionUpgradeOrEnchEquipped(player) && nightVisionActive) {
+            nightVisionActive = false;
+            removeNightvision = true;
+        }
         if (removeNightvision) {
             player.removePotionEffect(Potion.nightVision.getId());
             removeNightvision = false;


### PR DESCRIPTION
This reverts commit ce11a2dcf22905805fec45fbfe805a51eb163b81 from #231.

## Summary
Incorrect handle of night vision
Was causing the player's night vision to never apply

Tested in full pack by reverting to previous version


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
