### PR TITLE
Fix night vision deactivating after dimension change via portal

### DIFF
--- a/src/main/java/crazypants/enderio/item/KeyTracker.java
+++ b/src/main/java/crazypants/enderio/item/KeyTracker.java
@@ -337,32 +337,9 @@ public class KeyTracker {
     }
 
     private void handleNightVision() {
-        if (nightVisionKey.isPressed()) {
-            EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-            if (!DarkSteelController.instance.isNightVisionUpgradeOrEnchEquipped(player)) {
-                return;
-            }
-            boolean isActive = !DarkSteelController.instance.isNightVisionActive();
-            if (isActive) {
-                player.worldObj.playSound(
-                        player.posX,
-                        player.posY,
-                        player.posZ,
-                        EnderIO.DOMAIN + ":ds.nightvision.on",
-                        0.1f,
-                        player.worldObj.rand.nextFloat() * 0.4f - 0.2f + 1.0f,
-                        false);
-            } else {
-                player.worldObj.playSound(
-                        player.posX,
-                        player.posY,
-                        player.posZ,
-                        EnderIO.DOMAIN + ":ds.nightvision.off",
-                        0.1f,
-                        1.0f,
-                        false);
-            }
-            DarkSteelController.instance.setNightVisionActive(isActive);
+        if (nightVisionKey.isPressed() && DarkSteelController.instance
+                .isNightVisionUpgradeOrEnchEquipped(Minecraft.getMinecraft().thePlayer)) {
+            toggleDarkSteelController(Type.NIGHT_VISION, "darksteel.upgrade.nightVision");
         }
     }
 

--- a/src/main/java/crazypants/enderio/item/KeyTracker.java
+++ b/src/main/java/crazypants/enderio/item/KeyTracker.java
@@ -337,8 +337,17 @@ public class KeyTracker {
     }
 
     private void handleNightVision() {
-        if (nightVisionKey.isPressed() && DarkSteelController.instance
-                .isNightVisionUpgradeOrEnchEquipped(Minecraft.getMinecraft().thePlayer)) {
+        EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+        if (nightVisionKey.isPressed() && DarkSteelController.instance.isNightVisionUpgradeOrEnchEquipped(player)) {
+            boolean turningOn = !DarkSteelController.instance.isActive(player, Type.NIGHT_VISION);
+            player.worldObj.playSound(
+                    player.posX,
+                    player.posY,
+                    player.posZ,
+                    EnderIO.DOMAIN + (turningOn ? ":ds.nightvision.on" : ":ds.nightvision.off"),
+                    0.1f,
+                    turningOn ? player.worldObj.rand.nextFloat() * 0.4f - 0.2f + 1.0f : 1.0f,
+                    false);
             toggleDarkSteelController(Type.NIGHT_VISION, "darksteel.upgrade.nightVision");
         }
     }

--- a/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
@@ -570,13 +570,16 @@ public class DarkSteelController {
         if (player.worldObj.isRemote) {
             return;
         }
+        PotionEffect effect = player.getActivePotionEffect(Potion.nightVision);
         if (isNightVisionUpgradeOrEnchEquipped(player) && isActive(player, Type.NIGHT_VISION)) {
-            player.addPotionEffect(new PotionEffect(Potion.nightVision.getId(), 999999, 0, true));
-        } else {
-            PotionEffect effect = player.getActivePotionEffect(Potion.nightVision);
-            if (effect != null && effect.getIsAmbient()) {
-                player.removePotionEffect(Potion.nightVision.getId());
+            // Only (re)apply if there is no effect yet or ours is about to enter the sub-200-tick flicker window.
+            // Skipping non-ambient effects avoids flipping isAmbient via PotionEffect.combine(),
+            // which would prevent removal on toggle-off and strand the player with night vision indefinitely.
+            if (effect == null || (effect.getIsAmbient() && effect.getDuration() < 220)) {
+                player.addPotionEffect(new PotionEffect(Potion.nightVision.getId(), 400, 0, true));
             }
+        } else if (isNightVisionUpgradeOrEnchEquipped(player) && effect != null && effect.getIsAmbient()) {
+            player.removePotionEffect(Potion.nightVision.getId());
         }
     }
 

--- a/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
@@ -107,9 +107,6 @@ public class DarkSteelController {
 
     private final Map<UUID, EnumSet<Type>> allActive = new HashMap<>();
 
-    private boolean nightVisionActive = false;
-    private boolean removeNightvision = false;
-
     private DarkSteelController() {
         PacketHandler.INSTANCE.registerMessage(
                 PacketDarkSteelPowerPacket.class,
@@ -196,6 +193,8 @@ public class DarkSteelController {
             updateSwim(player);
 
             updateSolar(player);
+
+            updateNightvision(player);
         }
     }
 
@@ -447,7 +446,6 @@ public class DarkSteelController {
             if (player == null) {
                 return;
             }
-            updateNightvision(player);
             if (player.capabilities.isFlying) {
                 return;
             }
@@ -569,16 +567,16 @@ public class DarkSteelController {
     }
 
     private void updateNightvision(EntityPlayer player) {
-        if (isNightVisionUpgradeOrEnchEquipped(player) && nightVisionActive) {
-            player.addPotionEffect(new PotionEffect(Potion.nightVision.getId(), 210, 0, true));
+        if (player.worldObj.isRemote) {
+            return;
         }
-        if (!isNightVisionUpgradeOrEnchEquipped(player) && nightVisionActive) {
-            nightVisionActive = false;
-            removeNightvision = true;
-        }
-        if (removeNightvision) {
-            player.removePotionEffect(Potion.nightVision.getId());
-            removeNightvision = false;
+        if (isNightVisionUpgradeOrEnchEquipped(player) && isActive(player, Type.NIGHT_VISION)) {
+            player.addPotionEffect(new PotionEffect(Potion.nightVision.getId(), 999999, 0, true));
+        } else {
+            PotionEffect effect = player.getActivePotionEffect(Potion.nightVision);
+            if (effect != null && effect.getIsAmbient()) {
+                player.removePotionEffect(Potion.nightVision.getId());
+            }
         }
     }
 
@@ -620,14 +618,4 @@ public class DarkSteelController {
         return (NightVisionUpgrade.loadFromItem(helmet) != null || isNightVisionEnch(helmet));
     }
 
-    public void setNightVisionActive(boolean isNightVisionActive) {
-        if (nightVisionActive && !isNightVisionActive) {
-            removeNightvision = true;
-        }
-        this.nightVisionActive = isNightVisionActive;
-    }
-
-    public boolean isNightVisionActive() {
-        return nightVisionActive;
-    }
 }

--- a/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/DarkSteelController.java
@@ -571,14 +571,15 @@ public class DarkSteelController {
             return;
         }
         PotionEffect effect = player.getActivePotionEffect(Potion.nightVision);
-        if (isNightVisionUpgradeOrEnchEquipped(player) && isActive(player, Type.NIGHT_VISION)) {
-            // Only (re)apply if there is no effect yet or ours is about to enter the sub-200-tick flicker window.
-            // Skipping non-ambient effects avoids flipping isAmbient via PotionEffect.combine(),
-            // which would prevent removal on toggle-off and strand the player with night vision indefinitely.
+        boolean hasNVUpgrade = isNightVisionUpgradeOrEnchEquipped(player);
+        boolean isNVUpgradeEnabled = isActive(player, Type.NIGHT_VISION);
+        if (hasNVUpgrade && isNVUpgradeEnabled) {
+            // only (re)apply effect if ours is missing or about to expire
             if (effect == null || (effect.getIsAmbient() && effect.getDuration() < 220)) {
                 player.addPotionEffect(new PotionEffect(Potion.nightVision.getId(), 400, 0, true));
             }
-        } else if (isNightVisionUpgradeOrEnchEquipped(player) && effect != null && effect.getIsAmbient()) {
+        } else if (effect != null && effect.getIsAmbient() && (hasNVUpgrade || isNVUpgradeEnabled)) {
+            // if our effect exists and the player removed the upgrade item or toggled it off (both can't be true here)
             player.removePotionEffect(Potion.nightVision.getId());
         }
     }
@@ -613,8 +614,6 @@ public class DarkSteelController {
         }
         return false;
     }
-
-    // ---
 
     public boolean isNightVisionUpgradeOrEnchEquipped(EntityPlayer player) {
         ItemStack helmet = player.getEquipmentInSlot(4);

--- a/src/main/java/crazypants/enderio/item/darksteel/PacketUpgradeState.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/PacketUpgradeState.java
@@ -15,7 +15,8 @@ public class PacketUpgradeState implements IMessage, IMessageHandler<PacketUpgra
         GLIDE,
         SPEED,
         STEP_ASSIST,
-        JUMP
+        JUMP,
+        NIGHT_VISION
     }
 
     public PacketUpgradeState() {}


### PR DESCRIPTION
## Summary
The night vision upgrade was applied client-side only, which caused the effect to be lost every time the player crossed a portal. The fix moves application to the server side using onPlayerTick, so Minecraft's own packet system handles client sync and dimension changes are no longer a problem.

The toggle is integrated into the existing PacketUpgradeState infrastructure via a new NIGHT_VISION type, keeping per-player state and multiplayer sync consistent with other upgrades. On disable or unequip, the effect is only removed if it is ambient, so a manually-drunk potion of night vision is left untouched.

Effect duration is 400 ticks, refreshed only when it drops below 220 (the vanilla flicker threshold), reducing server packets from 20/sec to roughly one per 400 ticks. Non-ambient effects are skipped entirely to prevent PotionEffect.combine() from flipping isAmbient and stranding the player with permanent night vision on toggle-off.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge